### PR TITLE
feat(deps): upgrade TypeScript from 5.9.3 to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "husky": "9.1.7",
     "lint-staged": "16.4.0",
     "typedoc": "0.28.18",
-    "typescript": "5.9.3",
+    "typescript": "6.0.2",
     "vitest": "3.2.4"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
         version: 25.5.2
       "@typescript-eslint/eslint-plugin":
         specifier: 8.58.0
-        version: 8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
+        version: 8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(typescript@6.0.2)
       "@typescript-eslint/parser":
         specifier: 8.58.0
-        version: 8.58.0(eslint@10.2.0)(typescript@5.9.3)
+        version: 8.58.0(eslint@10.2.0)(typescript@6.0.2)
       "@vitest/coverage-v8":
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4(@types/node@25.5.2)(yaml@2.8.3))
@@ -30,10 +30,10 @@ importers:
         version: 16.4.0
       typedoc:
         specifier: 0.28.18
-        version: 0.28.18(typescript@5.9.3)
+        version: 0.28.18(typescript@6.0.2)
       typescript:
-        specifier: 5.9.3
-        version: 5.9.3
+        specifier: 6.0.2
+        version: 6.0.2
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@25.5.2)(yaml@2.8.3)
@@ -1938,10 +1938,10 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typescript@5.9.3:
+  typescript@6.0.2:
     resolution:
       {
-        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+        integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==,
       }
     engines: { node: ">=14.17" }
     hasBin: true
@@ -2399,40 +2399,40 @@ snapshots:
 
   "@types/unist@3.0.3": {}
 
-  "@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)":
+  "@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2))(eslint@10.2.0)(typescript@6.0.2)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.58.0(eslint@10.2.0)(typescript@5.9.3)
+      "@typescript-eslint/parser": 8.58.0(eslint@10.2.0)(typescript@6.0.2)
       "@typescript-eslint/scope-manager": 8.58.0
-      "@typescript-eslint/type-utils": 8.58.0(eslint@10.2.0)(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.58.0(eslint@10.2.0)(typescript@5.9.3)
+      "@typescript-eslint/type-utils": 8.58.0(eslint@10.2.0)(typescript@6.0.2)
+      "@typescript-eslint/utils": 8.58.0(eslint@10.2.0)(typescript@6.0.2)
       "@typescript-eslint/visitor-keys": 8.58.0
       eslint: 10.2.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@5.9.3)":
+  "@typescript-eslint/parser@8.58.0(eslint@10.2.0)(typescript@6.0.2)":
     dependencies:
       "@typescript-eslint/scope-manager": 8.58.0
       "@typescript-eslint/types": 8.58.0
-      "@typescript-eslint/typescript-estree": 8.58.0(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.58.0(typescript@6.0.2)
       "@typescript-eslint/visitor-keys": 8.58.0
       debug: 4.4.3
       eslint: 10.2.0
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.58.0(typescript@5.9.3)":
+  "@typescript-eslint/project-service@8.58.0(typescript@6.0.2)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.58.0(typescript@5.9.3)
+      "@typescript-eslint/tsconfig-utils": 8.58.0(typescript@6.0.2)
       "@typescript-eslint/types": 8.58.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -2441,47 +2441,47 @@ snapshots:
       "@typescript-eslint/types": 8.58.0
       "@typescript-eslint/visitor-keys": 8.58.0
 
-  "@typescript-eslint/tsconfig-utils@8.58.0(typescript@5.9.3)":
+  "@typescript-eslint/tsconfig-utils@8.58.0(typescript@6.0.2)":
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
-  "@typescript-eslint/type-utils@8.58.0(eslint@10.2.0)(typescript@5.9.3)":
+  "@typescript-eslint/type-utils@8.58.0(eslint@10.2.0)(typescript@6.0.2)":
     dependencies:
       "@typescript-eslint/types": 8.58.0
-      "@typescript-eslint/typescript-estree": 8.58.0(typescript@5.9.3)
-      "@typescript-eslint/utils": 8.58.0(eslint@10.2.0)(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.58.0(typescript@6.0.2)
+      "@typescript-eslint/utils": 8.58.0(eslint@10.2.0)(typescript@6.0.2)
       debug: 4.4.3
       eslint: 10.2.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
   "@typescript-eslint/types@8.58.0": {}
 
-  "@typescript-eslint/typescript-estree@8.58.0(typescript@5.9.3)":
+  "@typescript-eslint/typescript-estree@8.58.0(typescript@6.0.2)":
     dependencies:
-      "@typescript-eslint/project-service": 8.58.0(typescript@5.9.3)
-      "@typescript-eslint/tsconfig-utils": 8.58.0(typescript@5.9.3)
+      "@typescript-eslint/project-service": 8.58.0(typescript@6.0.2)
+      "@typescript-eslint/tsconfig-utils": 8.58.0(typescript@6.0.2)
       "@typescript-eslint/types": 8.58.0
       "@typescript-eslint/visitor-keys": 8.58.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.2)
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.58.0(eslint@10.2.0)(typescript@5.9.3)":
+  "@typescript-eslint/utils@8.58.0(eslint@10.2.0)(typescript@6.0.2)":
     dependencies:
       "@eslint-community/eslint-utils": 4.9.1(eslint@10.2.0)
       "@typescript-eslint/scope-manager": 8.58.0
       "@typescript-eslint/types": 8.58.0
-      "@typescript-eslint/typescript-estree": 8.58.0(typescript@5.9.3)
+      "@typescript-eslint/typescript-estree": 8.58.0(typescript@6.0.2)
       eslint: 10.2.0
-      typescript: 5.9.3
+      typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3148,24 +3148,24 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.2):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.2
 
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typedoc@0.28.18(typescript@5.9.3):
+  typedoc@0.28.18(typescript@6.0.2):
     dependencies:
       "@gerrit0/mini-shiki": 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 10.2.5
-      typescript: 5.9.3
+      typescript: 6.0.2
       yaml: 2.8.3
 
-  typescript@5.9.3: {}
+  typescript@6.0.2: {}
 
   uc.micro@2.1.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "types": ["node"],
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
## Summary
- Upgrades TypeScript from 5.9.3 to 6.0.2
- Adds explicit `types: ["node"]` to `tsconfig.json` — TS6 [changed the default](https://github.com/microsoft/TypeScript/issues/62508) from auto-including `@types/*` to `[]`
- All 165 tests pass, typecheck/build/lint/typedoc clean
- No other breaking changes affect this codebase (ESM, NodeNext resolution, strict mode already in use)

## TS6 Breaking Change Applied
| Change | Impact | Fix |
|--------|--------|-----|
| `types` defaults to `[]` | `process`, `node:fs`, `node:path` unresolved | Added `"types": ["node"]` |
| `esModuleInterop` always on | None (was already `true`) | No change needed |

## Test plan
- [x] Local: `pnpm typecheck && pnpm build && pnpm lint && pnpm run test:run` — 165/165 pass
- [x] TypeDoc build: clean (same 4 pre-existing warnings)
- [ ] CI passes on this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)