### PR TITLE
fix: exact window title match excludes Discord from EQ detection

### DIFF
--- a/scripts/adapt_display.sh
+++ b/scripts/adapt_display.sh
@@ -149,7 +149,7 @@ main() {
         nn_log "Step 4: Re-tiling running windows"
         local helper="${SCRIPT_DIR}/../helpers/wine_helper.exe"
         local eq_count
-        eq_count="$(DISPLAY=:0 xdotool search --name 'EverQuest' 2>/dev/null | wc -l)"
+        eq_count="$(nn_find_eq_windows | wc -l)"
 
         if [[ "${eq_count}" -gt 0 ]] && [[ -f "${helper}" ]]; then
             # Auto-tile based on window count

--- a/scripts/config_reader.sh
+++ b/scripts/config_reader.sh
@@ -31,6 +31,22 @@ nn_detect_wine() {
 # Initialize Wine command on source
 nn_detect_wine
 
+# ─── EQ Window Detection ─────────────────────────────────────────────────────
+# Find EQ windows by exact title match. xdotool --name is a substring match,
+# so "EverQuest" also matches Discord channels like "#everquest-news".
+# This filters to windows whose title is exactly "EverQuest".
+
+nn_find_eq_windows() {
+    local wid
+    while IFS= read -r wid; do
+        local title
+        title="$(DISPLAY=:0 xdotool getwindowname "${wid}" 2>/dev/null || echo '')"
+        if [[ "${title}" == "EverQuest" ]]; then
+            echo "${wid}"
+        fi
+    done < <(DISPLAY=:0 xdotool search --name "EverQuest" 2>/dev/null || true)
+}
+
 # ─── EQ Running Guard ─────────────────────────────────────────────────────────
 # Call this before modifying UI_*.ini or eqclient.ini files.
 # EQ holds these in memory and overwrites on camp/zone, so changes made

--- a/scripts/layout_calculator.sh
+++ b/scripts/layout_calculator.sh
@@ -72,11 +72,11 @@ apply_tiling() {
 
     nn_log "Wine desktop: ${desktop_w}x${desktop_h}"
 
-    # Find EQ game windows (excludes Wine desktop container)
+    # Find EQ game windows (exact title match, excludes Discord etc.)
     local -a real_windows=()
     while IFS= read -r wid; do
         real_windows+=("${wid}")
-    done < <(DISPLAY=:0 xdotool search --name "EverQuest" 2>/dev/null | head -6 || true)
+    done < <(nn_find_eq_windows | head -6)
 
     # Detect XWayland coordinate scaling (positions doubled on some compositors)
     local xw_scale=1

--- a/scripts/window_manager.sh
+++ b/scripts/window_manager.sh
@@ -87,9 +87,9 @@ move_window() {
 WINE_RESIZE_INDEX=0
 XWAYLAND_SCALE=1
 
-# Find EQ game windows (excludes the Wine virtual desktop container)
+# Find EQ game windows (exact title match, excludes Discord etc.)
 find_eq_windows() {
-    DISPLAY=:0 xdotool search --name "EverQuest" 2>/dev/null || true
+    nn_find_eq_windows
 }
 
 cmd_list() {


### PR DESCRIPTION
## Summary
- `make windows` was matching Discord windows containing "EverQuest" in channel names (e.g., `#everquest-news`)
- `xdotool search --name` does substring matching, not exact
- Added shared `nn_find_eq_windows()` to `config_reader.sh` that filters to exact `title == "EverQuest"`
- All 3 callers updated (DRY): `window_manager.sh`, `layout_calculator.sh`, `adapt_display.sh`
- Wine API path (`wine_helper.exe find`) already used `strcmp` exact match — unaffected

## Test plan
- [x] `make windows` no longer lists Discord windows
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)