### PR TITLE
fix: improve character identification and main window focus after tile

### DIFF
--- a/scripts/smart_tile.sh
+++ b/scripts/smart_tile.sh
@@ -78,95 +78,64 @@ main() {
         exit 1
     fi
 
-    # Map X11 WID→PID→character via PID→log file correlation
+    # Map X11 WID→PID→character via process start time ↔ login time correlation
+    #
+    # Strategy: EQ doesn't keep eqlog files open, so we can't use /proc/PID/fd.
+    # Instead, sort processes by creation time and characters by their "Welcome
+    # to EverQuest" log timestamp. The Nth process launched = Nth character to
+    # log in. This works because start_eq.sh launches instances with a stagger
+    # delay, so creation order matches login order.
     nn_log "Identifying characters..."
 
     local eq_dir="${PREFIX}/drive_c/EverQuest"
 
-    # Build PID→hwnd_index mapping for Wine windows
-    local -a pid_list=()
+    # Build (process_start, hwnd_index) sorted by start time
+    local -a proc_entries=()
     local i
     for (( i=0; i<count; i++ )); do
         local x11wid="${x11wid_list[i]}"
         local pid
         pid="$(DISPLAY=:0 xdotool getwindowpid "${x11wid}" 2>/dev/null || echo '0')"
-        pid_list+=("${pid}")
+        local proc_start
+        proc_start="$(stat -c '%Z' "/proc/${pid}" 2>/dev/null || echo '0')"
+        proc_entries+=("${proc_start}:${i}")
     done
+    mapfile -t proc_entries < <(printf '%s\n' "${proc_entries[@]}" | sort -n)
 
-    # Build PID→character mapping via /proc/PID open file descriptors.
-    # Each EQ instance has its log file open: eqlog_CharName_Server.txt
-    # This is more reliable than timestamp correlation because it's a
-    # direct link from process to character, not a sorted-order guess.
-    local -A pid_to_char=()
-    for (( i=0; i<count; i++ )); do
-        local pid="${pid_list[i]}"
-        [[ "${pid}" == "0" ]] && continue
-
-        # Check /proc/PID/fd for open eqlog files
-        local cname=""
-        for fd in /proc/"${pid}"/fd/*; do
-            local target
-            target="$(readlink "${fd}" 2>/dev/null || echo '')"
-            if [[ "${target}" == *"/Logs/eqlog_"*".txt" ]]; then
-                cname="$(basename "${target}" | sed 's/eqlog_//;s/_[^_]*\.txt//')"
-                break
-            fi
-        done
-
-        if [[ -n "${cname}" ]]; then
-            pid_to_char["${pid}"]="${cname}"
+    # Build (login_time, char_name) sorted by login time
+    # Use "Welcome to EverQuest" from eqlog files — only consider recent sessions
+    local -a char_entries=()
+    local now
+    now="$(date '+%s')"
+    for logfile in "${eq_dir}"/Logs/eqlog_*_*.txt; do
+        [[ -f "${logfile}" ]] || continue
+        local cname
+        cname="$(basename "${logfile}" | sed 's/eqlog_//;s/_[^_]*\.txt//')"
+        local login_epoch
+        login_epoch="$(grep 'Welcome to EverQuest' "${logfile}" 2>/dev/null | tail -1 | grep -oP '\[.*?\]' | sed 's/[][]//g' | xargs -I{} date -d '{}' '+%s' 2>/dev/null || echo '0')"
+        # Only match characters who logged in within the last 12 hours
+        if [[ "${login_epoch}" -gt 0 ]] && [[ $((now - login_epoch)) -lt 43200 ]]; then
+            char_entries+=("${login_epoch}:${cname}")
         fi
     done
+    mapfile -t char_entries < <(printf '%s\n' "${char_entries[@]}" | sort -n)
 
-    # Fallback: if /proc/PID/fd didn't work (permissions), use timestamp correlation
-    if [[ ${#pid_to_char[@]} -eq 0 ]]; then
-        nn_log "  (using timestamp fallback for character identification)"
-
-        # Sort processes by start time
-        local -a proc_entries=()
-        for (( i=0; i<count; i++ )); do
-            local proc_start
-            proc_start="$(stat -c '%Z' "/proc/${pid_list[i]}" 2>/dev/null || echo '0')"
-            proc_entries+=("${proc_start}:${i}")
-        done
-        mapfile -t proc_entries < <(printf '%s\n' "${proc_entries[@]}" | sort -n)
-
-        # Sort characters by log file mtime (more reliable than parsing Welcome message)
-        local -a char_entries=()
-        for logfile in "${eq_dir}"/Logs/eqlog_*_*.txt; do
-            [[ -f "${logfile}" ]] || continue
-            local cname
-            cname="$(basename "${logfile}" | sed 's/eqlog_//;s/_[^_]*\.txt//')"
-            local mtime
-            mtime="$(stat -c '%Y' "${logfile}" 2>/dev/null || echo '0')"
-            # Only consider log files modified in the last hour (active sessions)
-            local now
-            now="$(date '+%s')"
-            if [[ $((now - mtime)) -lt 3600 ]]; then
-                char_entries+=("${mtime}:${cname}")
-            fi
-        done
-        mapfile -t char_entries < <(printf '%s\n' "${char_entries[@]}" | sort -n)
-
-        local match_count=${#proc_entries[@]}
-        if [[ ${#char_entries[@]} -lt ${match_count} ]]; then
-            match_count=${#char_entries[@]}
-        fi
-
-        for (( i=0; i<match_count; i++ )); do
-            local idx="${proc_entries[i]##*:}"
-            local cname="${char_entries[i]##*:}"
-            pid_to_char["${pid_list[idx]}"]="${cname}"
-        done
-    fi
-
-    # Assign character names to HWND indices
+    # Match 1:1 by sorted position (1st process = 1st login, etc.)
     local -a char_names=()
     for (( i=0; i<count; i++ )); do
-        local pid="${pid_list[i]}"
-        local cname="${pid_to_char[${pid}]:-unknown}"
-        char_names+=("${cname}")
-        nn_log "  ${cname} → HWND ${hwnd_list[i]}"
+        char_names+=("unknown")
+    done
+
+    local match_count=${#proc_entries[@]}
+    if [[ ${#char_entries[@]} -lt ${match_count} ]]; then
+        match_count=${#char_entries[@]}
+    fi
+
+    for (( i=0; i<match_count; i++ )); do
+        local hwnd_idx="${proc_entries[i]##*:}"
+        local cname="${char_entries[i]##*:}"
+        char_names[hwnd_idx]="${cname}"
+        nn_log "  ${cname} → HWND ${hwnd_list[hwnd_idx]}"
     done
 
     # Find main character index
@@ -223,10 +192,15 @@ main() {
     nn_log "Applying via Wine API..."
     WINEPREFIX="${PREFIX}" DISPLAY=:0 wine "${helper}" tile-hwnd "${tile_args[@]}" 2>/dev/null
 
-    # Explicitly focus the main character window so it receives keyboard input.
-    # Without this, the terminal that ran `make tile` keeps keyboard focus.
+    # Focus the main character window so it receives keyboard input.
+    # Wine's SetForegroundWindow doesn't always work from background processes,
+    # so we also use xdotool at the X11 level as a belt-and-suspenders approach.
     sleep 0.3
     WINEPREFIX="${PREFIX}" DISPLAY=:0 wine "${helper}" focus-hwnd "0x${hwnd_list[main_idx]}" 2>/dev/null || true
+    sleep 0.1
+    local main_x11wid="${x11wid_list[main_idx]}"
+    DISPLAY=:0 xdotool windowactivate --sync "${main_x11wid}" 2>/dev/null || true
+    DISPLAY=:0 xdotool windowfocus --sync "${main_x11wid}" 2>/dev/null || true
 
     nn_log ""
     nn_log "Tiling complete. ${char_names[main_idx]} is the main window (focused)."


### PR DESCRIPTION
## Summary
Fixes remaining tiling issues from PR #66:

### Malware in main slot instead of Grenlan
- Created `norrath-native.yaml` with `main_character: Grenlan` (gitignored, user-local)
- Without this, main defaults to index 0 which is whatever Wine EnumWindows returns first (non-deterministic)

### Character identification improvements
- Reverted /proc/PID/fd approach — EQ doesn't keep eqlog files open (writes and closes immediately)
- Restored "Welcome to EverQuest" timestamp parsing from eqlog files (verified correct: process start order matches login order due to stagger delay)
- Added 12-hour session window filter to ignore stale log entries from previous sessions

### Grenlan window not accepting keyboard input
- Added `xdotool windowactivate --sync` + `xdotool windowfocus --sync` as X11-level backup after Wine's `SetForegroundWindow`
- Wine's `SetForegroundWindow` can fail when called from a background process (the terminal). xdotool operates at the X11 level and reliably transfers focus

### Debug session findings
| PID | Started | Character | Login Time |
|-----|---------|-----------|------------|
| 2330300 | 19:50:25 | Grenlan | 19:51:11 |
| 2331404 | 19:51:42 | Malware | 19:52:34 |
| 2335125 | 19:55:50 | Rootkit | 19:56:46 |

Process start order = login order ✓ (stagger delay ensures this)

## Test plan
- [x] `make tile` puts Grenlan in the main (big left) window
- [x] Main window receives keyboard focus after tile
- [x] All windows accept click + keyboard input
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)