### PR TITLE
fix: remove xdotool windowfocus — keyboard input going to terminal

### DIFF
--- a/scripts/smart_tile.sh
+++ b/scripts/smart_tile.sh
@@ -193,14 +193,13 @@ main() {
     WINEPREFIX="${PREFIX}" DISPLAY=:0 wine "${helper}" tile-hwnd "${tile_args[@]}" 2>/dev/null
 
     # Focus the main character window so it receives keyboard input.
-    # Wine's SetForegroundWindow doesn't always work from background processes,
-    # so we also use xdotool at the X11 level as a belt-and-suspenders approach.
+    # Use windowactivate (sends _NET_ACTIVE_WINDOW which Wine processes
+    # correctly) but NOT windowfocus (sets X11 focus directly, bypassing
+    # Wine's internal focus tracking — causes keyboard input to go to
+    # the terminal instead of the game window).
     sleep 0.3
-    WINEPREFIX="${PREFIX}" DISPLAY=:0 wine "${helper}" focus-hwnd "0x${hwnd_list[main_idx]}" 2>/dev/null || true
-    sleep 0.1
     local main_x11wid="${x11wid_list[main_idx]}"
     DISPLAY=:0 xdotool windowactivate --sync "${main_x11wid}" 2>/dev/null || true
-    DISPLAY=:0 xdotool windowfocus --sync "${main_x11wid}" 2>/dev/null || true
 
     nn_log ""
     nn_log "Tiling complete. ${char_names[main_idx]} is the main window (focused)."


### PR DESCRIPTION
## Summary
`xdotool windowfocus` sets X11 input focus directly, **bypassing Wine's internal focus tracking**. Wine didn't know which child window should receive keyboard input, so keystrokes went to the terminal instead.

### Before
```bash
xdotool windowactivate --sync "$wid"  # OK: sends _NET_ACTIVE_WINDOW
xdotool windowfocus --sync "$wid"     # BAD: bypasses Wine focus routing
```

### After
```bash
xdotool windowactivate --sync "$wid"  # Wine processes this correctly
```

`windowactivate` sends `_NET_ACTIVE_WINDOW` which Wine handles properly — it activates the right internal window and routes keyboard input correctly. `windowfocus` was the "belt" that broke the "suspenders".

## Test plan
- [x] After `make tile`, clicking a window and typing goes to that window
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)