### PR TITLE
fix: tile within Wine virtual desktop, not physical monitor

### DIFF
--- a/scripts/config_reader.sh
+++ b/scripts/config_reader.sh
@@ -47,6 +47,22 @@ nn_find_eq_windows() {
     done < <(DISPLAY=:0 xdotool search --name "EverQuest" 2>/dev/null || true)
 }
 
+# ─── Wine Desktop Size Detection ─────────────────────────────────────────────
+# Returns the Wine virtual desktop size if configured, otherwise the physical
+# monitor size. EQ windows are constrained to the virtual desktop — tiling
+# must use this size, not the monitor size.
+
+nn_get_screen_size() {
+    local prefix="${NN_PREFIX:-${HOME}/.wine-eq}"
+    local vdesktop
+    vdesktop="$(grep -oP '"Default"="\K[^"]+' "${prefix}/user.reg" 2>/dev/null || echo '')"
+    if [[ "${vdesktop}" =~ ^[0-9]+x[0-9]+$ ]]; then
+        echo "${vdesktop%%x*} ${vdesktop##*x}"
+    else
+        DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null
+    fi
+}
+
 # ─── EQ Running Guard ─────────────────────────────────────────────────────────
 # Call this before modifying UI_*.ini or eqclient.ini files.
 # EQ holds these in memory and overwrites on camp/zone, so changes made

--- a/scripts/smart_tile.sh
+++ b/scripts/smart_tile.sh
@@ -57,11 +57,11 @@ main() {
         exit 1
     fi
 
-    # Get screen size
+    # Get screen size — uses Wine virtual desktop if configured.
+    # EQ windows are constrained to the virtual desktop, not the physical monitor.
     local screen_w screen_h
-    screen_w="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f1)"
-    screen_h="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f2)"
-    nn_log "Screen: ${screen_w}x${screen_h}"
+    read -r screen_w screen_h <<< "$(nn_get_screen_size)"
+    nn_log "Tiling area: ${screen_w}x${screen_h}"
 
     # Get HWND→X11 WID mapping from Wine
     nn_log "Mapping windows via Wine API..."

--- a/scripts/window_manager.sh
+++ b/scripts/window_manager.sh
@@ -122,10 +122,9 @@ cmd_tile() {
         exit 1
     fi
 
-    # Get screen dimensions
+    # Get screen dimensions (uses Wine virtual desktop if configured)
     local screen_w screen_h
-    screen_w="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f1)"
-    screen_h="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f2)"
+    read -r screen_w screen_h <<< "$(nn_get_screen_size)"
 
     # Detect XWayland coordinate scaling
     XWAYLAND_SCALE="$(detect_xwayland_scale "${windows[0]}")"
@@ -182,8 +181,7 @@ cmd_pip() {
     fi
 
     local screen_w screen_h
-    screen_w="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f1)"
-    screen_h="$(DISPLAY=:0 xdotool getdisplaygeometry 2>/dev/null | cut -d' ' -f2)"
+    read -r screen_w screen_h <<< "$(nn_get_screen_size)"
 
     local main_w=$((screen_w * 3 / 4))
     local pip_w=$((screen_w - main_w))


### PR DESCRIPTION
## Summary
Tiling was using `xdotool getdisplaygeometry` (3440x1440 physical monitor) but EQ windows live inside a Wine virtual desktop (2256x1504). Box windows were positioned at x=2236, overflowing the 2256px-wide virtual desktop — making Malware's window unclickable.

### Root cause
```
Physical monitor: 3440x1440
Wine virtual desktop: 2256x1504   ← EQ windows are constrained to this
Main window: 65% of 3440 = 2236px ← almost fills the entire virtual desktop
Box at x=2236: only 20px visible  ← effectively off-screen
```

### Fix
New `nn_get_screen_size()` in `config_reader.sh` reads Wine virtual desktop resolution from `user.reg`. Falls back to physical monitor if no virtual desktop.

```
After: 65% of 2256 = 1466px main, boxes at x=1466 (790px visible) ✓
```

### DRY
All three callers updated: `smart_tile.sh`, `window_manager.sh` (tile + pip commands).

## Test plan
- [x] `nn_get_screen_size` returns `2256 1504` (virtual desktop)
- [x] `make tile` positions all windows within virtual desktop
- [x] All windows clickable and accept keyboard input
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)