### PR TITLE
fix: 1px origin offset prevents Wine desktop from eating clicks

### DIFF
--- a/scripts/smart_tile.sh
+++ b/scripts/smart_tile.sh
@@ -160,14 +160,20 @@ main() {
     nn_log "Main: ${char_names[main_idx]}"
 
     # Build tile specs: main gets 65% left, boxes stack right
+    #
+    # IMPORTANT: Wine virtual desktop frame sits at (0,0). A child window
+    # also at (0,0) won't receive mouse clicks because the desktop frame
+    # intercepts them. Offset by 1px to avoid this.
+    local origin_x=1
+    local origin_y=1
     local -a tile_args=()
 
     if [[ "${count}" -eq 1 ]] || [[ "${TEMPLATE}" == "solo" ]]; then
-        tile_args+=("0x${hwnd_list[0]}" "0,0,${screen_w}x${screen_h}")
+        tile_args+=("0x${hwnd_list[0]}" "${origin_x},${origin_y},$((screen_w - origin_x))x$((screen_h - origin_y))")
     elif [[ "${TEMPLATE}" == "equal" ]]; then
         local hw=$((screen_w / 2))
         local hh=$((screen_h / 2))
-        local positions=("0,0,${hw}x${hh}" "${hw},0,${hw}x${hh}" "0,${hh},${hw}x${hh}" "${hw},${hh},${hw}x${hh}")
+        local positions=("${origin_x},${origin_y},$((hw - origin_x))x$((hh - origin_y))" "${hw},${origin_y},$((hw))x$((hh - origin_y))" "${origin_x},${hh},$((hw - origin_x))x${hh}" "${hw},${hh},${hw}x${hh}")
         for (( i=0; i<count && i<4; i++ )); do
             tile_args+=("0x${hwnd_list[i]}" "${positions[i]}")
         done
@@ -179,9 +185,9 @@ main() {
         if [[ "${box_count}" -lt 1 ]]; then box_count=1; fi
         local box_h=$((screen_h / box_count))
 
-        # Main character gets the big window (prefix HWND with 0x for C parsing)
-        tile_args+=("0x${hwnd_list[main_idx]}" "0,0,${main_w}x${screen_h}")
-        nn_log "  ${char_names[main_idx]}: (0,0) ${main_w}x${screen_h} [MAIN]"
+        # Main character gets the big window, offset 1px from origin
+        tile_args+=("0x${hwnd_list[main_idx]}" "${origin_x},${origin_y},$((main_w - origin_x))x$((screen_h - origin_y))")
+        nn_log "  ${char_names[main_idx]}: (${origin_x},${origin_y}) $((main_w - origin_x))x$((screen_h - origin_y)) [MAIN]"
 
         # Boxes stack on the right
         local box_i=0


### PR DESCRIPTION
## Summary
Wine's virtual desktop frame sits at (0,0). An EQ child window also at (0,0) doesn't receive mouse clicks — the desktop frame intercepts them. This made the main (largest) window unclickable while box windows at other positions worked fine.

### Debugging session
1. `make status` showed all windows positioned correctly
2. Clicking Malware and Rootkit (at 2236,0 and 2236,720) worked
3. Clicking Grenlan (at 0,0) did nothing — couldn't select or type
4. `xdotool windowactivate` failed with `XGetWindowProperty` errors on all windows (red herring — Wine virtual desktop children don't have standard X11 properties)
5. Wine `focus-hwnd` + `list` showed correct Z-order internally
6. Moving Grenlan to (1,1) immediately fixed clicking

### Root cause
Wine virtual desktop frame at (0,0) captures input events before they reach a child window at the same origin. This is a Wine/XWayland compositor interaction bug.

### Fix
All tile positions that would be at origin (0,0) are offset to (1,1). The 1px difference is invisible but prevents the desktop frame from intercepting clicks.

## Test plan
- [x] Main window at (1,1) accepts clicks and keyboard input
- [x] Box windows continue to work
- [x] 172 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)