### PR TITLE
feat: auto-install .NET 8 runtime before parser

### DIFF
--- a/scripts/install_parser.sh
+++ b/scripts/install_parser.sh
@@ -115,6 +115,11 @@ if [[ "${DOTNET_ONLY}" -eq 1 ]]; then
     exit 0
 fi
 
+# ─── Ensure .NET 8 is installed ──────────────────────────────────────────────
+# Auto-detect and install if missing — parser won't run without it.
+
+install_dotnet
+
 # ─── Idempotency Check ──────────────────────────────────────────────────────
 
 if [[ "${FORCE_UPDATE}" -eq 0 ]] && [[ -f "${PARSER_EXE}" ]]; then


### PR DESCRIPTION
## Summary
`make parser` now auto-detects and silently installs .NET 8 Desktop Runtime if missing. No manual `--dotnet` step needed.

### Flow
1. Check `wine dotnet --list-runtimes` for `Microsoft.WindowsDesktop.App 8`
2. If missing: download from Microsoft, install via `wine ... /quiet /norestart`
3. If present: skip (idempotent)
4. Proceed to download and install EQLogParser

One command: `make parser` — handles everything.

## Test plan
- [x] ShellCheck clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)