### PR TITLE
fix: .NET 8 download URL was broken (400 Bad Request)

### DIFF
--- a/scripts/install_parser.sh
+++ b/scripts/install_parser.sh
@@ -93,7 +93,8 @@ install_dotnet() {
     fi
 
     info "Downloading .NET 8.0 Desktop Runtime..."
-    local dotnet_url="https://download.visualstudio.microsoft.com/download/pr/f18288a0-1554-4f3a-966b-c702baa3b9dc/windowsdesktop-runtime-8.0.16-win-x64.exe"
+    # aka.ms redirect always points to the latest .NET 8.x patch release
+    local dotnet_url="https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe"
     local dotnet_file
     dotnet_file="$(mktemp --suffix=.exe)"
     trap 'rm -f "${dotnet_file}"' RETURN


### PR DESCRIPTION
## Summary
The hardcoded .NET 8 Desktop Runtime download URL returned 400 Bad Request (stale Microsoft CDN link).

**Fix:** Use `https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe` which always redirects to the latest .NET 8.x patch release (currently 8.0.25, 56MB).

## Test plan
- [x] URL resolves: `wget --spider` returns 200 OK via redirect
- [ ] `make parser` downloads and installs successfully
- [ ] CI passes

Sources:
- [.NET 8.0 Downloads](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)