### PR TITLE
feat: upgrade Wine 9.0 → 11.x via WineHQ repo (#89, #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ _Three EQ instances tiled on an ultrawide monitor — Grenlan (main, 16:9) with 
 
 ## Prerequisites
 
-| Requirement    | Minimum Version     | Notes                                              |
-| -------------- | ------------------- | -------------------------------------------------- |
-| Ubuntu         | 24.04 LTS           | Target platform (Mint, Pop!\_OS also work)         |
-| Wine           | 9.0 (stable)        | 64-bit prefix, auto-detected as `wine` or `wine64` |
-| Vulkan drivers | mesa-vulkan-drivers | GPU must support Vulkan (Intel, AMD, NVIDIA)       |
-| Node.js        | 22.x LTS            | TypeScript config tooling                          |
-| pnpm           | 10.x                | Package manager                                    |
+| Requirement    | Minimum Version      | Notes                                             |
+| -------------- | -------------------- | ------------------------------------------------- |
+| Ubuntu         | 24.04 LTS            | Target platform (Mint, Pop!\_OS also work)        |
+| Wine           | 11.0 (WineHQ stable) | Auto-installed from WineHQ repo by `make prereqs` |
+| Vulkan drivers | mesa-vulkan-drivers  | GPU must support Vulkan (Intel, AMD, NVIDIA)      |
+| Node.js        | 22.x LTS             | TypeScript config tooling                         |
+| pnpm           | 10.x                 | Package manager                                   |
 
 Don't worry about installing these manually — `make prereqs` handles everything.
 

--- a/scripts/config_reader.sh
+++ b/scripts/config_reader.sh
@@ -17,12 +17,12 @@ nn_log() {
     printf '[%s] %s\n' "${timestamp}" "$*"
 }
 
-# Detect Wine binary (wine64 or wine)
+# Detect Wine binary (prefer wine, fallback to wine64 for older installs)
 nn_detect_wine() {
-    if command -v wine64 &>/dev/null; then
-        NN_WINE_CMD="wine64"
-    elif command -v wine &>/dev/null; then
+    if command -v wine &>/dev/null; then
         NN_WINE_CMD="wine"
+    elif command -v wine64 &>/dev/null; then
+        NN_WINE_CMD="wine64"
     else
         NN_WINE_CMD=""
     fi

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -8,13 +8,11 @@ set -euo pipefail
 SCRIPT_NAME="$(basename "$0")"
 readonly SCRIPT_NAME
 readonly LOG_DIR="${HOME}/.local/share/norrath-native"
-readonly MIN_WINE_VERSION="9.0"
+readonly MIN_WINE_VERSION="11.0"
 
-# Required packages for 64-bit Wine + Vulkan on Ubuntu 24.04
+# Required packages for Wine + Vulkan on Ubuntu 24.04
+# Wine is installed from WineHQ repo (see install_wine_from_winehq)
 readonly -a REQUIRED_PACKAGES=(
-    # Wine (stable)
-    wine64
-    wine32
     # Vulkan drivers and tools
     mesa-vulkan-drivers
     "mesa-vulkan-drivers:i386"
@@ -114,6 +112,37 @@ enable_i386() {
     fi
 }
 
+install_wine_from_winehq() {
+    nn_log "Setting up WineHQ repository for Wine 11..."
+
+    # Check if Wine 11+ is already installed
+    if command -v wine &>/dev/null; then
+        local current_version
+        current_version="$(wine --version 2>/dev/null | sed 's/wine-//' | cut -d'.' -f1)"
+        if [[ "${current_version}" -ge 11 ]] 2>/dev/null; then
+            nn_log "  Wine ${current_version}.x already installed, skipping"
+            return 0
+        fi
+    fi
+
+    # Add WineHQ signing key
+    if [[ ! -f /etc/apt/keyrings/winehq-archive.key ]]; then
+        nn_log "  Adding WineHQ signing key..."
+        run sudo mkdir -pm755 /etc/apt/keyrings
+        run sudo wget -qO /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+    fi
+
+    # Add WineHQ repository for Ubuntu 24.04 (Noble)
+    if [[ ! -f /etc/apt/sources.list.d/winehq-noble.sources ]]; then
+        nn_log "  Adding WineHQ Noble repository..."
+        run sudo wget -qNP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
+        run sudo apt-get update -qq
+    fi
+
+    nn_log "  Installing winehq-stable..."
+    run sudo apt-get install -y --install-recommends winehq-stable
+}
+
 install_packages() {
     local -a packages=("$@")
     local -a to_install=()
@@ -138,13 +167,13 @@ install_packages() {
 verify_wine() {
     nn_log "Verifying Wine installation..."
 
-    if ! command -v wine64 &>/dev/null; then
-        nn_log "ERROR: wine64 not found after installation"
+    if ! command -v wine &>/dev/null; then
+        nn_log "ERROR: wine not found after installation"
         return 1
     fi
 
     local wine_version
-    wine_version=$(wine64 --version 2>/dev/null | sed 's/wine-//')
+    wine_version=$(wine --version 2>/dev/null | sed 's/wine-//')
     nn_log "  Wine version: ${wine_version}"
 
     # Simple version floor check (compare major.minor)
@@ -208,25 +237,29 @@ main() {
     enable_i386
 
     nn_log ""
-    nn_log "Step 2/5: Update package lists"
+    nn_log "Step 2/6: Install Wine 11 from WineHQ"
+    install_wine_from_winehq
+
+    nn_log ""
+    nn_log "Step 3/6: Update package lists"
     run sudo apt-get update -qq
 
     nn_log ""
-    nn_log "Step 3/5: Install required packages"
+    nn_log "Step 4/6: Install required packages"
     install_packages "${REQUIRED_PACKAGES[@]}"
 
     if [[ "${SKIP_OPTIONAL}" -eq 0 ]]; then
         nn_log ""
-        nn_log "Step 4/5: Install optional packages"
+        nn_log "Step 5/6: Install optional packages"
         install_packages "${OPTIONAL_PACKAGES[@]}"
     else
         nn_log ""
-        nn_log "Step 4/5: Skipping optional packages (--skip-optional)"
+        nn_log "Step 5/6: Skipping optional packages (--skip-optional)"
     fi
 
     if [[ "${DRY_RUN}" -eq 0 ]]; then
         nn_log ""
-        nn_log "Step 5/5: Verify installation"
+        nn_log "Step 6/6: Verify installation"
         verify_wine
         verify_vulkan
     else

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -77,7 +77,7 @@ export interface DxvkRelease {
 // ---------------------------------------------------------------------------
 
 /** Minimum Wine version required (major.minor) */
-export const MIN_WINE_VERSION = "9.0";
+export const MIN_WINE_VERSION = "11.0";
 
 /** Minimum DXVK version required (major.minor) */
 export const MIN_DXVK_VERSION = "2.4";


### PR DESCRIPTION
## Summary
Upgrades from Ubuntu's Wine 9.0 to WineHQ's Wine 11.x stable. This enables EQLogParser (WPF app) and brings significant performance/compatibility improvements.

### What changes
- `make prereqs` now adds the WineHQ repository and installs `winehq-stable` (Wine 11.x)
- `nn_detect_wine()` prefers `wine` over `wine64` (wine64 removed in Wine 11)
- `MIN_WINE_VERSION` bumped to 11.0
- README prerequisites table updated

### Wine 11 improvements for EQ
| Feature | Impact |
|---------|--------|
| WPF text layout engine | EQLogParser actually works |
| Wine-Mono 8.0 | Better .NET app support |
| WoW64 completion | 32-bit apps without i386 libs |
| NTSYNC | Major perf boost (kernel 6.14+) |
| EGL default | Better OpenGL path |

### Migration
Existing installs: run `make prereqs` to upgrade Wine. The Wine prefix is forward-compatible — no need to recreate it.

Closes #89, closes #93.

## Test plan
- [x] 172 tests pass
- [x] Stats verification clean
- [x] ShellCheck clean
- [ ] `make prereqs` installs Wine 11 from WineHQ
- [ ] EQ launches on Wine 11
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)