### PR TITLE
fix: auto-install Wine Mono — prevents interactive dialog during parser install

### DIFF
--- a/scripts/deploy_eq_env.sh
+++ b/scripts/deploy_eq_env.sh
@@ -120,11 +120,26 @@ create_wineprefix() {
 
     if [[ -d "${PREFIX}" ]]; then
         nn_log "Prefix already exists, skipping init."
-        return 0
+    else
+        run env WINEPREFIX="${PREFIX}" WINEARCH=win64 wineboot --init
+        nn_log "WINEPREFIX created."
     fi
 
-    run env WINEPREFIX="${PREFIX}" WINEARCH=win64 wineboot --init
-    nn_log "WINEPREFIX created."
+    # Install Wine Mono if not present (needed for .NET apps like EQLogParser).
+    # Without this, Wine shows an interactive dialog the first time a .NET app runs.
+    if [[ ! -d "${PREFIX}/drive_c/windows/mono" ]]; then
+        nn_log "Installing Wine Mono (.NET support)..."
+        if command -v winetricks &>/dev/null; then
+            run env WINEPREFIX="${PREFIX}" winetricks -q mono
+        else
+            # Trigger Mono auto-download by running a wineboot update.
+            # DISPLAY="" suppresses the GUI dialog; Wine downloads Mono silently.
+            run env WINEPREFIX="${PREFIX}" DISPLAY="" wineboot --update
+        fi
+        nn_log "Wine Mono installed."
+    else
+        nn_log "Wine Mono already installed."
+    fi
 }
 
 install_dxvk_dlls() {

--- a/scripts/install_parser.sh
+++ b/scripts/install_parser.sh
@@ -86,6 +86,12 @@ done
 install_dotnet() {
     info "Checking for .NET 8 Desktop Runtime..."
 
+    # Ensure Wine Mono is installed (prevents interactive dialog)
+    if [[ ! -d "${PREFIX}/drive_c/windows/mono" ]]; then
+        info "Installing Wine Mono first..."
+        WINEPREFIX="${PREFIX}" DISPLAY="" wineboot --update 2>/dev/null || true
+    fi
+
     # Check if already installed
     if WINEPREFIX="${PREFIX}" wine dotnet --list-runtimes 2>/dev/null | grep -q 'Microsoft.WindowsDesktop.App 8'; then
         ok ".NET 8 Desktop Runtime already installed"


### PR DESCRIPTION
## Summary
Running `make parser` triggered a Wine Mono installer dialog that blocked the process. Users had to manually click "Install" before the parser installation could proceed.

### Fix
Install Wine Mono automatically in two places:
1. **`make deploy`** — during `create_wineprefix()`, after prefix init
2. **`make parser`** — before .NET 8 runtime install, as a safety check

Uses `winetricks -q mono` if available, otherwise `DISPLAY="" wineboot --update` which triggers Mono's silent auto-download without showing the GUI dialog.

### Detection
Checks for `${PREFIX}/drive_c/windows/mono` directory — if present, skip.

## Test plan
- [x] ShellCheck clean
- [x] 172 tests pass
- [ ] `make parser` completes without interactive dialog
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)