### PR TITLE
feat: auto-create desktop shortcuts with proper icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ norrath-native/
     dxvk-resolver.ts     — GitHub API DXVK release resolver
     metadata.ts          — Programmatic project stats (self-documenting)
     types/interfaces.ts  — Core TypeScript contracts
-  scripts/               — 20 bash scripts (thin system wrappers)
+  scripts/               — 21 bash scripts (thin system wrappers)
   tests/                 — 9 test files
   layouts/               — 4 window layout templates
   helpers/wine_helper.c  — Wine API helper (SetWindowPos, HWND mapping)

--- a/scripts/deploy_eq_env.sh
+++ b/scripts/deploy_eq_env.sh
@@ -483,6 +483,10 @@ main() {
     nn_log ""
     bash "${SCRIPT_DIR}/install_maps.sh" --prefix "${PREFIX}" || warn "Map installation failed (non-fatal)"
 
+    # Create desktop shortcuts and taskbar pins
+    nn_log ""
+    bash "${SCRIPT_DIR}/install_shortcuts.sh" || warn "Shortcut creation failed (non-fatal)"
+
     nn_log "=== ${SCRIPT_NAME} completed ==="
     nn_log "Run 'make doctor' to verify installation, 'make launch' to play."
 }

--- a/scripts/install_parser.sh
+++ b/scripts/install_parser.sh
@@ -198,12 +198,14 @@ WINEPREFIX="${PREFIX}" wine "${installer_path}" 2>/dev/null || true
 # Verify installation
 if [[ -f "${PARSER_EXE}" ]]; then
     ok "EQLogParser installed successfully at ${PARSER_DEST}"
+
+    # Create desktop shortcut and pin to taskbar
+    bash "${SCRIPT_DIR}/install_shortcuts.sh" --parser-only 2>/dev/null || true
+
     info ""
-    info "Launch with:"
-    info "  WINEPREFIX=${PREFIX} wine \"${PARSER_EXE}\""
-    info ""
-    info "In EQLogParser → Settings → Triggers, enable 'Use Piper TTS'"
-    info "for trigger audio (Windows TTS is unavailable under Wine)."
+    info "EQLogParser pinned to your taskbar. Tips:"
+    info "  In Settings → Triggers, enable 'Use Piper TTS'"
+    info "  (Windows TTS is unavailable under Wine)"
 else
     warn "EQLogParser.exe not found after installation."
     warn "The installer may have used a different path."

--- a/scripts/install_shortcuts.sh
+++ b/scripts/install_shortcuts.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install_shortcuts.sh — Create desktop shortcuts and taskbar pins
+#
+# Creates .desktop entries for EverQuest and EQLogParser with proper
+# icons, and pins them to the GNOME taskbar (favorites).
+#
+# Called automatically by deploy and parser install scripts.
+# Safe to run multiple times (idempotent).
+#
+# Usage: bash scripts/install_shortcuts.sh [--parser-only]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=config_reader.sh
+source "${SCRIPT_DIR}/config_reader.sh"
+
+PREFIX="${NN_PREFIX}"
+PARSER_ONLY=0
+APPS_DIR="${HOME}/.local/share/applications"
+ICONS_DIR="${HOME}/.local/share/icons/norrath-native"
+
+if [[ "${1:-}" == "--parser-only" ]]; then
+    PARSER_ONLY=1
+fi
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    cat <<EOF
+Usage: $(basename "$0") [--parser-only]
+
+Create desktop shortcuts with proper icons for EQ and EQLogParser.
+
+Options:
+  --parser-only   Only create/update EQLogParser shortcut
+  -h, --help      Show this help
+EOF
+    exit 0
+fi
+
+mkdir -p "${APPS_DIR}" "${ICONS_DIR}"
+
+# ─── Icon Extraction ──────────────────────────────────────────────────────────
+
+install_eq_icon() {
+    local ico_src="${PREFIX}/drive_c/EverQuest/Everquest.ico"
+    local icon_dest="${ICONS_DIR}/everquest.png"
+
+    if [[ -f "${icon_dest}" ]]; then
+        return 0
+    fi
+
+    if [[ -f "${ico_src}" ]]; then
+        # Convert .ico to .png via ImageMagick (pick largest layer)
+        if command -v convert &>/dev/null; then
+            convert "${ico_src}[0]" -resize 128x128 "${icon_dest}" 2>/dev/null && return 0
+        fi
+        # Fallback: copy the .ico directly (GNOME can display it)
+        cp "${ico_src}" "${ICONS_DIR}/everquest.ico" 2>/dev/null
+        icon_dest="${ICONS_DIR}/everquest.ico"
+    fi
+}
+
+install_parser_icon() {
+    local icon_dest="${ICONS_DIR}/eqlogparser.png"
+
+    if [[ -f "${icon_dest}" ]]; then
+        return 0
+    fi
+
+    # Try to extract icon from the .exe via icoutils
+    local exe="${PREFIX}/drive_c/Program Files/EQLogParser/EQLogParser.exe"
+    if [[ -f "${exe}" ]] && command -v wrestool &>/dev/null && command -v icotool &>/dev/null; then
+        local tmp_ico
+        tmp_ico="$(mktemp --suffix=.ico)"
+        wrestool -x -t 14 "${exe}" > "${tmp_ico}" 2>/dev/null || true
+        if [[ -s "${tmp_ico}" ]]; then
+            icotool -x -o "${icon_dest}" "${tmp_ico}" 2>/dev/null || true
+        fi
+        rm -f "${tmp_ico}"
+    fi
+
+    # If no icon extracted, use a generic game icon
+    if [[ ! -f "${icon_dest}" ]]; then
+        # Use the EQ icon as fallback, or wine icon
+        if [[ -f "${ICONS_DIR}/everquest.png" ]]; then
+            cp "${ICONS_DIR}/everquest.png" "${icon_dest}"
+        fi
+    fi
+}
+
+# ─── Desktop Entries ──────────────────────────────────────────────────────────
+
+create_eq_shortcut() {
+    local desktop_file="${APPS_DIR}/everquest.desktop"
+
+    install_eq_icon
+
+    local icon_path="${ICONS_DIR}/everquest.png"
+    if [[ ! -f "${icon_path}" ]]; then
+        icon_path="${ICONS_DIR}/everquest.ico"
+    fi
+    if [[ ! -f "${icon_path}" ]]; then
+        icon_path="wine"
+    fi
+
+    cat > "${desktop_file}" << EOF
+[Desktop Entry]
+Name=EverQuest
+Comment=Launch EverQuest via Wine (norrath-native)
+Exec=env WINEPREFIX=${PREFIX} wine ${PREFIX}/drive_c/EverQuest/LaunchPad.exe --disable-gpu
+Type=Application
+Categories=Game;
+Icon=${icon_path}
+StartupWMClass=launchpad.exe
+EOF
+
+    nn_log "Created EverQuest shortcut: ${desktop_file}"
+}
+
+create_parser_shortcut() {
+    local desktop_file="${APPS_DIR}/eqlogparser.desktop"
+    local exe="${PREFIX}/drive_c/Program Files/EQLogParser/EQLogParser.exe"
+
+    if [[ ! -f "${exe}" ]]; then
+        return 0
+    fi
+
+    install_parser_icon
+
+    local icon_path="${ICONS_DIR}/eqlogparser.png"
+    if [[ ! -f "${icon_path}" ]]; then
+        icon_path="wine"
+    fi
+
+    cat > "${desktop_file}" << EOF
+[Desktop Entry]
+Name=EQLogParser
+Comment=EverQuest DPS meter and trigger system
+Exec=env WINEPREFIX=${PREFIX} wine "${exe}"
+Type=Application
+Categories=Game;Utility;
+Icon=${icon_path}
+StartupWMClass=eqlogparser.exe
+EOF
+
+    nn_log "Created EQLogParser shortcut: ${desktop_file}"
+}
+
+# ─── Taskbar Pinning ──────────────────────────────────────────────────────────
+
+pin_to_taskbar() {
+    local app_id="$1"
+
+    # Only works on GNOME
+    if ! command -v gsettings &>/dev/null; then
+        return 0
+    fi
+
+    local current
+    current="$(gsettings get org.gnome.shell favorite-apps 2>/dev/null || echo '[]')"
+
+    # Check if already pinned
+    if echo "${current}" | grep -q "'${app_id}'"; then
+        return 0
+    fi
+
+    # Add to favorites
+    local updated
+    updated="$(echo "${current}" | sed "s/]/, '${app_id}']/" | sed "s/\[, /[/")"
+    gsettings set org.gnome.shell favorite-apps "${updated}" 2>/dev/null || true
+    nn_log "Pinned ${app_id} to taskbar"
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+if [[ "${PARSER_ONLY}" -eq 0 ]]; then
+    create_eq_shortcut
+    pin_to_taskbar "everquest.desktop"
+fi
+
+create_parser_shortcut
+pin_to_taskbar "eqlogparser.desktop"
+
+nn_log "Desktop shortcuts installed."


### PR DESCRIPTION
## Summary
Desktop shortcuts with proper icons are now created automatically during installation.

### What's new
- **`make deploy`** creates EverQuest shortcut with the actual EQ icon (extracted from `Everquest.ico`)
- **`make parser`** creates EQLogParser shortcut after installation
- Both auto-pin to the GNOME taskbar (favorites)

### Desktop entries
| App | Icon | Pinned |
|-----|------|--------|
| EverQuest | Everquest.ico → 128x128 PNG | Yes |
| EQLogParser | EQ icon (fallback) | Yes |

### Implementation
New `scripts/install_shortcuts.sh`:
- Converts `.ico` → `.png` via ImageMagick
- Creates `.desktop` entries in `~/.local/share/applications/`
- Pins to GNOME favorites via `gsettings`
- Idempotent — safe to run multiple times
- `--parser-only` flag for parser-only updates

## Test plan
- [x] EQ icon extracted and displayed correctly
- [x] Shortcuts appear in GNOME dock
- [x] ShellCheck clean
- [x] 172 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)