### PR TITLE
fix: EQLogParser crash on minimize — disable DWM composition

### DIFF
--- a/scripts/deploy_eq_env.sh
+++ b/scripts/deploy_eq_env.sh
@@ -291,6 +291,14 @@ tune_wine_registry() {
         'HKEY_CURRENT_USER\Software\Wine\X11 Driver' \
         /v Managed /d N /f
 
+    # Disable DWM desktop composition — WPF apps (EQLogParser) crash on
+    # minimize when DwmIsCompositionEnabled returns true, because Wine's
+    # dwmapi stubs don't implement the required composition APIs.
+    # See: https://github.com/dotnet/wpf/issues/4166
+    run env WINEPREFIX="${PREFIX}" "${NN_WINE_CMD}" reg add \
+        'HKEY_CURRENT_USER\Software\Wine\DWM' \
+        /v DisableComposition /d Y /f
+
     # Hint VRAM size for Intel Iris Xe (prevents DX11 fallback paths)
     run env WINEPREFIX="${PREFIX}" "${NN_WINE_CMD}" reg add \
         'HKEY_CURRENT_USER\Software\Wine\Direct3D' \

--- a/scripts/install_shortcuts.sh
+++ b/scripts/install_shortcuts.sh
@@ -136,7 +136,7 @@ create_parser_shortcut() {
 [Desktop Entry]
 Name=EQLogParser
 Comment=EverQuest DPS meter and trigger system
-Exec=env WINEPREFIX=${PREFIX} wine "${exe}"
+Exec=env WINEPREFIX=${PREFIX} MONO_THREADS_SUSPEND=preemptive wine "${exe}"
 Type=Application
 Categories=Game;Utility;
 Icon=${icon_path}


### PR DESCRIPTION
## Summary
EQLogParser (WPF/.NET 8) crashes when clicking minimize. Root cause: Wine's `dwmapi` stubs.

### Debug findings
```
022c:fixme:dwmapi:DwmAttachMilContent (0000000000020094) stub
022c:warn:seh:dispatch_exception unknown exception (code=e0434352) raised
0264:fixme:dwmapi:DwmGetCompositionTimingInfo (…) stub
0264:fixme:dwmapi:DwmFlush stub
```

WPF calls `DwmIsCompositionEnabled` on minimize → returns true → calls `DwmAttachMilContent` etc. → Wine stubs → .NET exception → crash.

### Fix
```bash
wine reg add 'HKCU\Software\Wine\DWM' /v DisableComposition /d Y /f
```

This makes `DwmIsCompositionEnabled` return false. WPF skips the DWM path entirely.

Also: `MONO_THREADS_SUSPEND=preemptive` in EQLogParser shortcut per [dotnet/wpf#4166](https://github.com/dotnet/wpf/issues/4166).

## Test plan
- [x] DWM registry applied to current prefix
- [x] Shortcut updated with MONO_THREADS_SUSPEND
- [ ] EQLogParser minimize works without crash
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sources:
- [dotnet/wpf#4166 — DwmIsCompositionEnabled crash on Wine](https://github.com/dotnet/wpf/issues/4166)
- [WPF on Wine guide](https://ccifra.github.io/PortingWPFAppsToLinux/Overview.html)