### PR TITLE
fix: read-only eqclient.ini prevents multibox exit race condition

### DIFF
--- a/scripts/configure_eq.sh
+++ b/scripts/configure_eq.sh
@@ -109,6 +109,11 @@ main() {
 
     nn_log "Applying settings (profile: ${NN_PROFILE}) to ${ini_file}"
 
+    # Temporarily make writable (may be read-only from previous configure)
+    if [[ -f "${ini_file}" ]] && [[ "${DRY_RUN}" -eq 0 ]]; then
+        chmod 644 "${ini_file}" 2>/dev/null || true
+    fi
+
     if [[ ! -f "${ini_file}" ]]; then
         if [[ "${DRY_RUN}" -eq 1 ]]; then
             nn_log "[DRY-RUN] Would create ${ini_file}"
@@ -127,6 +132,15 @@ main() {
         nn_log "All settings already correct (no changes needed)."
     else
         nn_log "Applied ${total} change(s)."
+    fi
+
+    # Make eqclient.ini read-only to prevent race condition when
+    # multiple EQ instances exit simultaneously. The last instance
+    # to exit would overwrite settings from other instances.
+    # make configure temporarily makes it writable for updates.
+    if [[ "${DRY_RUN}" -eq 0 ]]; then
+        chmod 444 "${ini_file}"
+        nn_log "Set ${ini_file} read-only (prevents multibox exit race)."
     fi
 }
 


### PR DESCRIPTION
## Summary
When 3 EQ instances exit simultaneously, the last one overwrites `eqclient.ini` with its settings, losing config from the other instances.

**Fix:** `make configure` now sets `eqclient.ini` to read-only (444) after applying settings. Temporarily makes it writable (644) at the start for updates.

### Investigation: shared vs separate Wine prefixes (#100)

| Approach | Disk | Window Management | Crash Isolation | eqclient.ini |
|----------|------|-------------------|-----------------|--------------|
| **Shared prefix (current)** | 18GB | wine_helper.exe works | wineserver shared | Race on exit |
| Separate prefixes | 22GB | **BREAKS** EnumWindows | Full isolation | No race |

**Decision:** Stay with shared prefix. EnumWindows (tiling, focus, status) requires single wineserver. Mitigate ini race with read-only flag.

Consensus vote: 2 approve, 1 reject (architect rejected the *switch*, approved staying put).

Closes #100.

## Test plan
- [x] 172 tests pass
- [x] ShellCheck clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)