### PR TITLE
feat: enable NTSYNC for kernel-level Wine performance

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -90,6 +90,15 @@ check_system_deps() {
         fail "SYS_VULKAN" "vulkaninfo not found" "run: make prereqs"
     fi
 
+    # NTSYNC (kernel-level Wine performance)
+    if [[ -c /dev/ntsync ]]; then
+        pass "SYS_NTSYNC" "NTSYNC active (/dev/ntsync) — kernel-level Wine sync"
+    elif modinfo ntsync &>/dev/null 2>&1; then
+        warn "SYS_NTSYNC" "NTSYNC module available but not loaded" "run: make prereqs"
+    else
+        warn "SYS_NTSYNC" "NTSYNC not available (kernel may be < 6.14)" "optional: upgrade kernel for better Wine performance"
+    fi
+
     # ntlm_auth (winbind)
     if command -v ntlm_auth &>/dev/null; then
         pass "SYS_NTLM" "ntlm_auth (winbind) available"

--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -217,6 +217,39 @@ verify_vulkan() {
     fi
 }
 
+enable_ntsync() {
+    nn_log "Enabling NTSYNC (Wine performance optimization)..."
+
+    # NTSYNC requires kernel 6.14+ and the ntsync module
+    if [[ -c /dev/ntsync ]]; then
+        nn_log "  NTSYNC already active (/dev/ntsync exists)"
+        return 0
+    fi
+
+    # Check if module is available
+    if ! modinfo ntsync &>/dev/null; then
+        nn_log "  NTSYNC module not available (kernel may be too old)"
+        nn_log "  This is optional — Wine will work without it, just slower"
+        return 0
+    fi
+
+    # Load the module
+    nn_log "  Loading ntsync kernel module..."
+    run sudo modprobe ntsync
+
+    # Make persistent across reboots
+    if [[ ! -f /etc/modules-load.d/ntsync.conf ]]; then
+        run sudo bash -c 'echo ntsync > /etc/modules-load.d/ntsync.conf'
+        nn_log "  NTSYNC set to load on boot"
+    fi
+
+    if [[ -c /dev/ntsync ]]; then
+        nn_log "  NTSYNC enabled — Wine will use kernel-level synchronization"
+    else
+        nn_log "  NTSYNC module loaded but /dev/ntsync not created (may need reboot)"
+    fi
+}
+
 # ─── Main ─────────────────────────────────────────────────────────────────────
 
 main() {
@@ -261,14 +294,18 @@ main() {
         nn_log "Step 5/6: Skipping optional packages (--skip-optional)"
     fi
 
+    nn_log ""
+    nn_log "Step 6/7: Enable NTSYNC (kernel-level Wine performance)"
+    enable_ntsync
+
     if [[ "${DRY_RUN}" -eq 0 ]]; then
         nn_log ""
-        nn_log "Step 6/6: Verify installation"
+        nn_log "Step 7/7: Verify installation"
         verify_wine
         verify_vulkan
     else
         nn_log ""
-        nn_log "Step 5/5: Skipping verification (dry-run mode)"
+        nn_log "Step 7/7: Skipping verification (dry-run mode)"
     fi
 
     nn_log ""


### PR DESCRIPTION
## Summary
NTSYNC provides kernel-level synchronization for Wine, replacing the slower userspace wineserver sync. Significant CPU reduction for multiboxing.

### What's NTSYNC?
Wine traditionally uses a userspace daemon (wineserver) to emulate Windows synchronization primitives (mutexes, events, semaphores). NTSYNC moves this to the kernel via `/dev/ntsync`, eliminating context switches between Wine processes and the wineserver.

### What's new
- `make prereqs` loads the `ntsync` kernel module and persists it across reboots
- `make doctor` checks NTSYNC status (active / available / not available)

### Requirements
- Linux kernel 6.14+ (we're on 6.17 ✅)
- Wine 11+ (already required ✅)

### From #91 research
This was the key finding: Wine 11 + NTSYNC = equivalent performance to GE-Proton. No need to switch runtimes.

Closes #91 (already closed with analysis).

## Test plan
- [x] NTSYNC module loaded (`/dev/ntsync` exists)
- [x] Persists across reboot (`/etc/modules-load.d/ntsync.conf`)
- [x] Doctor check works
- [x] 172 tests pass, ShellCheck clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)