### PR TITLE
feat: real EQLogParser icon + EQ log path symlink

### DIFF
--- a/scripts/install_parser.sh
+++ b/scripts/install_parser.sh
@@ -232,13 +232,26 @@ WINEPREFIX="${PARSER_PREFIX}" wine "${installer_path}" \
 if [[ -f "${PARSER_EXE}" ]]; then
     ok "EQLogParser installed successfully at ${PARSER_DEST}"
 
+    # Symlink EQ directory into parser prefix so EQLogParser can find logs.
+    # EQLogParser looks for logs at C:\EverQuest\Logs\ — the symlink makes
+    # the EQ prefix's game files visible in the parser prefix.
+    eq_dir="${NN_PREFIX}/drive_c/EverQuest"
+    parser_eq_link="${PARSER_PREFIX}/drive_c/EverQuest"
+    if [[ -d "${eq_dir}" ]] && [[ ! -e "${parser_eq_link}" ]]; then
+        ln -sfn "${eq_dir}" "${parser_eq_link}"
+        ok "Linked EQ logs into parser prefix (C:\\EverQuest\\Logs\\)"
+    fi
+
     # Create desktop shortcut and pin to taskbar
     bash "${SCRIPT_DIR}/install_shortcuts.sh" --parser-only 2>/dev/null || true
 
     info ""
-    info "EQLogParser pinned to your taskbar. Tips:"
-    info "  In Settings → Triggers, enable 'Use Piper TTS'"
-    info "  (Windows TTS is unavailable under Wine)"
+    info "EQLogParser pinned to your taskbar."
+    info ""
+    info "First launch setup:"
+    info "  1. File → Open → navigate to C:\\EverQuest\\Logs\\"
+    info "  2. Select eqlog_${NN_MAIN_CHARACTER:-YourCharacter}_*.txt"
+    info "  3. Settings → Triggers → enable 'Use Piper TTS'"
 else
     warn "EQLogParser.exe not found after installation."
     warn "The installer may have used a different path."

--- a/scripts/install_shortcuts.sh
+++ b/scripts/install_shortcuts.sh
@@ -68,12 +68,20 @@ install_parser_icon() {
     fi
 
     # Try to extract icon from the .exe via icoutils
-    local exe="${PREFIX}/drive_c/Program Files/EQLogParser/EQLogParser.exe"
+    local parser_prefix="${HOME}/.wine-eqlogparser"
+    local exe="${parser_prefix}/drive_c/Program Files/EQLogParser/EQLogParser.exe"
+    # Fallback to EQ prefix for old installs
+    if [[ ! -f "${exe}" ]]; then
+        exe="${PREFIX}/drive_c/Program Files/EQLogParser/EQLogParser.exe"
+    fi
+
     if [[ -f "${exe}" ]] && command -v wrestool &>/dev/null && command -v icotool &>/dev/null; then
         local tmp_ico
         tmp_ico="$(mktemp --suffix=.ico)"
         wrestool -x -t 14 "${exe}" > "${tmp_ico}" 2>/dev/null || true
         if [[ -s "${tmp_ico}" ]]; then
+            # Extract the largest icon layer
+            icotool -x -w 48 -o "${icon_dest}" "${tmp_ico}" 2>/dev/null || \
             icotool -x -o "${icon_dest}" "${tmp_ico}" 2>/dev/null || true
         fi
         rm -f "${tmp_ico}"


### PR DESCRIPTION
## Summary
Two QoL improvements for EQLogParser.

### Real icon
Extracts the actual EQLogParser icon (bar chart) from the .exe using `wrestool`/`icotool` instead of using the generic EQ icon as fallback. The icon shows in the GNOME taskbar when the parser is running.

### EQ log access
EQLogParser runs in its own Wine prefix (`~/.wine-eqlogparser`), but EQ logs are in the EQ prefix (`~/.wine-eq/drive_c/EverQuest/Logs/`). A symlink bridges them:

```
~/.wine-eqlogparser/drive_c/EverQuest → ~/.wine-eq/drive_c/EverQuest
```

So in EQLogParser: File → Open → `C:\EverQuest\Logs\eqlog_Grenlan_povar.txt`

First-launch instructions printed after install point users to the main character's log.

## Test plan
- [x] Real icon extracted and displayed
- [x] Symlink works (EQ logs visible in parser prefix)
- [x] ShellCheck clean
- [x] 172 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)