### PR TITLE
docs: comprehensive documentation with frontmatter

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+---
+title: Documentation Index
+description: All norrath-native documentation
+updated: auto-generated
+---
+
+# norrath-native Documentation
+
+## User Guides
+
+| Guide                                     | Description                               |
+| ----------------------------------------- | ----------------------------------------- |
+| [Getting Started](getting-started.md)     | Quick start, installation, first launch   |
+| [Multiboxing](multiboxing.md)             | Multiple instances, tiling, focus cycling |
+| [EQLogParser Setup](eqlogparser-setup.md) | DPS meter, triggers, GINA compatibility   |
+| [Troubleshooting](troubleshooting.md)     | Common issues and fixes                   |
+
+## Reference
+
+| Document                         | Description                           |
+| -------------------------------- | ------------------------------------- |
+| [Command Reference](commands.md) | All make targets and script usage     |
+| [Doctor Checks](checks.md)       | Health check descriptions and status  |
+| [Chat Layout](chat-layout.md)    | 4-window chat channel routing         |
+| [API Reference](api/)            | TypeDoc-generated TypeScript API docs |
+
+## Architecture
+
+Each EQ instance runs as a native XWayland window. Window management
+uses `wine_helper.exe` (MinGW-compiled Win32 API calls via Wine).
+EQLogParser runs in its own isolated Wine prefix.
+
+For more details, see [AGENTS.md](../AGENTS.md) and the source code.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1,34 +1,65 @@
+---
+title: Doctor Checks Reference
+description: Health check descriptions and categories
+source: src/doctor.ts, scripts/doctor.sh
+updated: auto-generated
+---
+
 # Doctor Checks Reference
 
-*Auto-generated from doctor --json output. Do not edit manually.*
+_Run `make doctor` to see current status. Run `make doctor --json` for machine-readable output._
 
-| ID | Description | Status |
-|---|---|---|
-| `SYS_WINE` | wine 9.0 (Ubuntu 9.0~repack-4build3) | pass |
-| `SYS_VULKAN` | Vulkan: Intel(R) Iris(R) Xe Graphics (ADL GT2) | pass |
-| `SYS_NTLM` | ntlm_auth (winbind) available | pass |
-| `SYS_NODE` | Node.js v22.22.0 | pass |
-| `PREFIX_EXISTS` | WINEPREFIX exists: /home/william/.wine-eq | pass |
-| `PREFIX_ARCH` | Architecture: win64 | pass |
-| `PREFIX_VDESKTOP` | Virtual desktop 1920x1080 does not match monitor 3440x1440 | warn |
-| `PREFIX_COREFONTS` | Microsoft core fonts installed (arial.ttf present) | pass |
-| `PREFIX_MOUSE_CAPTURE` | Mouse capture configured (MouseWarpOverride=enable) | pass |
-| `DXVK_SYS32_D3D11` | d3d11.dll in system32 (x64) | pass |
-| `DXVK_WOW64_D3D11` | d3d11.dll in syswow64 (x32) | pass |
-| `DXVK_SYS32_DXGI` | dxgi.dll in system32 (x64) | pass |
-| `DXVK_WOW64_DXGI` | dxgi.dll in syswow64 (x32) | pass |
-| `DXVK_OVERRIDE_D3D11` | DLL override: d3d11=native | pass |
-| `DXVK_OVERRIDE_DXGI` | DLL override: dxgi=native | pass |
-| `EQ_DIR` | EQ directory: /home/william/.wine-eq/drive_c/EverQuest | pass |
-| `EQ_LAUNCHER` | LaunchPad.exe (PE32) | pass |
-| `EQ_INI` | eqclient.ini configured with managed settings | pass |
-| `EQ_LOGGING` | EQ log file generation enabled (Log=TRUE) | pass |
-| `EQ_PATCHED` | Game patched (16G on disk) | pass |
-| `EQ_REMEMBER_ME` | Remember Me enabled (auto-login active) | pass |
-| `EQ_MAPS` | Brewall maps not installed | warn |
-| `EQ_PARSER` | EQLogParser not installed (optional DPS meter + trigger system) | warn |
-| `STATE_DEPLOYED_AT` | Deployed at: 2026-04-04T16:35:20-04:00 | pass |
-| `STATE_WINE_VERSION` | Wine version: 9.0 (Ubuntu 9.0~repack-4build3) | pass |
-| `STATE_DXVK_VERSION` | DXVK version: 2.7.1 | pass |
-| `LOG_DIR` | Log directory: /home/william/.local/share/norrath-native (5 log files) | pass |
-| `LOG_LAST_DEPLOY` | Last deploy: 2026-04-04 16:35:20 | pass |
+## System Dependencies
+
+| Check        | Description                                |
+| ------------ | ------------------------------------------ |
+| `SYS_WINE`   | Wine installed (11.0+ recommended)         |
+| `SYS_VULKAN` | Vulkan GPU drivers and vulkaninfo          |
+| `SYS_NTSYNC` | NTSYNC kernel module (performance)         |
+| `SYS_NTLM`   | winbind/ntlm_auth (prevents Wine warnings) |
+| `SYS_NODE`   | Node.js 22.x LTS                           |
+
+## Wine Prefix
+
+| Check                  | Description                         |
+| ---------------------- | ----------------------------------- |
+| `PREFIX_EXISTS`        | WINEPREFIX directory exists         |
+| `PREFIX_ARCH`          | Prefix is win64 architecture        |
+| `PREFIX_COREFONTS`     | Microsoft core fonts installed      |
+| `PREFIX_MOUSE_CAPTURE` | MouseWarpOverride=enable configured |
+
+## DXVK (DirectX 11 → Vulkan)
+
+| Check                 | Description                 |
+| --------------------- | --------------------------- |
+| `DXVK_SYS32_D3D11`    | d3d11.dll in system32 (x64) |
+| `DXVK_WOW64_D3D11`    | d3d11.dll in syswow64 (x32) |
+| `DXVK_SYS32_DXGI`     | dxgi.dll in system32 (x64)  |
+| `DXVK_WOW64_DXGI`     | dxgi.dll in syswow64 (x32)  |
+| `DXVK_OVERRIDE_D3D11` | DLL override: d3d11=native  |
+| `DXVK_OVERRIDE_DXGI`  | DLL override: dxgi=native   |
+
+## EverQuest Installation
+
+| Check            | Description                      |
+| ---------------- | -------------------------------- |
+| `EQ_DIR`         | EverQuest directory exists       |
+| `EQ_LAUNCHER`    | LaunchPad.exe present            |
+| `EQ_INI`         | eqclient.ini exists              |
+| `EQ_LOGGING`     | Logging enabled (Log=TRUE)       |
+| `EQ_PATCHED`     | Game binary present (eqgame.exe) |
+| `EQ_REMEMBER_ME` | Remember Me cookie database      |
+| `EQ_MAPS`        | Good's maps installed            |
+| `EQ_DXVK_CONF`   | DXVK config (async shaders)      |
+| `EQ_PARSER`      | EQLogParser installed            |
+
+## Deploy State
+
+| Check                | Description               |
+| -------------------- | ------------------------- |
+| `STATE_FILE`         | Deploy state file exists  |
+| `STATE_DEPLOYED_AT`  | Deploy timestamp recorded |
+| `STATE_WINE_VERSION` | Wine version recorded     |
+| `STATE_DXVK_VERSION` | DXVK version recorded     |
+| `LOG_DIR`            | Log directory exists      |
+| `LOG_LAST_DEPLOY`    | Deploy log exists         |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,360 +1,55 @@
+---
+title: Command Reference
+description: All available make targets
+source: Makefile
+updated: auto-generated
+---
+
 # Command Reference
 
-*Auto-generated from script --help output. Do not edit manually.*
-
-## Makefile Targets
-
-```
-make: Entering directory '/home/william/git/norrath-native'
-backup-session     Back up launcher login session for disaster recovery
-clean              Remove build artifacts and coverage
-colors-preview     Preview color scheme changes without applying
-colors             Apply optimized chat color scheme for raid readability
-configure-dry      Preview INI changes without writing
-configure          Apply optimized eqclient.ini settings
-deploy-dry         Preview deployment without making changes
-deploy             Full deployment (prefix + DXVK + EQ install + config)
-docs-check         Verify generated docs are up to date (CI mode)
-docs               Generate API docs, command reference, and check reference
-doctor             Health check — validate entire installation
-focus-next         Cycle keyboard focus to the next EQ window
-help               Show this help
-install            Install pnpm dependencies
-launch-multi       Launch multibox instances (default: 3, set multibox_instances in config)
-launch             Launch a single EverQuest instance
-layout-apply       Apply a layout template (TEMPLATE=name, e.g., multibox-bard-pull)
-layout-preview     Preview chat layout changes without applying
-layout-show        Preview a layout template's calculated positions
-layout-templates   List available layout templates
-layout             Apply recommended 4-window chat layout (Social/Combat/Spam/Alerts)
-lint               Run ESLint with project rules
-maps               Install Brewall's map pack (FILE=path/to/downloaded.zip)
-parser             Install EQLogParser DPS meter + trigger system (PARSER_FILE=path/to/downloaded.zip)
-pip                Picture-in-picture: main window large, others stacked right
-prereqs-dry        Preview prerequisite installation without changes
-prereqs            Install system prerequisites (Wine, Vulkan, etc.)
-profile-list       List available UI layout profiles
-profile-load       Load a saved UI layout profile (PROFILE=name)
-profile-save       Save current UI layout as a named profile (PROFILE=name)
-purge              Remove Wine prefix and all EQ data (DESTRUCTIVE)
-resolution-detect  Show detected monitor resolution vs current Wine resolution
-resolution         Set Wine + EQ resolution to match your monitor (auto-detect)
-restore-session    Restore launcher session from backup
-setup-all          Apply ALL customizations to ALL characters (config + colors + layout + resolution)
-support-bundle     Generate a support bundle for troubleshooting
-test-coverage      Run tests with coverage report
-test               Run Vitest test suite
-tile               Arrange EQ windows in a grid layout (auto-detects count)
-typecheck          Run TypeScript strict type checking
-windows            List all detected EQ windows
-make: Leaving directory '/home/william/git/norrath-native'
-```
-
-## apply_colors
-
-```
-Usage: apply_colors.sh [OPTIONS]
-
-Apply an optimized chat color scheme to eqclient.ini.
-
-The scheme is designed for raid readability:
-  - Tells: bright pink (unmissable)
-  - Guild: bright green
-  - Group: soft blue
-  - Raid:  orange
-  - Your damage: warm yellow/gold
-  - Your healing: cool mint/blue
-  - Others' combat: dimmed gray (red[docs]   Written: /home/william/git/norrath-native/scripts/../docs/commands.md
-[docs] Generating doctor checks reference...
-[docs]   Written: /home/william/git/norrath-native/scripts/../docs/checks.md
-[docs] Documentation generation complete
-```
-
-## install_prerequisites
-
-```
-Usage: install_prerequisites.sh [OPTIONS]
-
-Install all system prerequisites for norrath-native (EverQuest on Linux).
-
-Options:
-    --dry-run         Show what would be installed without making changes
-    --skip-optional   Skip optional packages (fonts, winetricks)
-    -h, --help        Show this help message
-
-Requires: Ubuntu 24.04 LTS, sudo access
-```
-
-## start_eq
-
-```
-Usage: start_eq.sh [OPTIONS]
-
-Launch EverQuest instances under Wine with optional multi-boxing support.
-
-Options:
-  --multi                Use multibox_instances from config (default: 3)
-  --instances N          Override instance count
-  --stagger-delay SECS   Delay between instance launches (default: 5)
-  --prefix PATH          WINEPREFIX path (default: ~/.wine-eq)
-  --eq-dir PATH          EverQuest install directory (default: auto-detect)
-  --wayland              Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-ng Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-    EverQuest install directory (default: auto-detect)
-  --wayland              Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-m config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-ons:
-    --dry-run         Show what would be installed without making changes
-    --skip-optional   Skip optional packages (fonts, winetricks)
-    -h, --help        Show this help message
-
-Requires: Ubuntu 24.04 LTS, sudo access
-```
-
-## start_eq
-
-```
-Usage: start_eq.sh [OPTIONS]
-
-Launch EverQuest instances under Wine with optional multi-boxing support.
-
-Options:
-  --multi                Use multibox_instances from config (default: 3)
-  --instances N          Override instance count
-  --stagger-delay SECS   Delay between instance launches (default: 5)
-  --prefix PATH          WINEPREFIX path (default: ~/.wine-eq)
-  --eq-dir PATH          EverQuest install directory (default: auto-detect)
-  --wayland              Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-unch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-       Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
- start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-   EverQuest install directory (default: auto-detect)
-  --wayland              Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-id focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-h (default: ~/.wine-eq)
-  --eq-dir PATH          EverQuest install directory (default: auto-detect)
-  --wayland              Use Wayland display backend instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-ow all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
- instead of X11
-  --dry-run              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-## window_manager
-
-```
-Usage: window_manager.sh <command>
-
-Manage EverQuest windows for multiboxing.
-
-Commands:
-  tile       Arrange all EQ windows in a grid layout
-  focus      Cycle focus to the next EQ window
-  list       Show all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-     Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
- tools.
-```
-
-n              Print what would be launched without starting Wine
-  -h, --help             Show this help message
-
-Environment:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-## window_manager
-
-```
-Usage: window_manager.sh <command>
-
-Manage EverQuest windows for multiboxing.
-
-Commands:
-  tile       Arrange all EQ windows in a grid layout
-  focus      Cycle focus to the next EQ window
-  list       Show all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-ow all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-t:
-  NORRATH_WAYLAND=1      Alternative way to enable Wayland backend
-
-Examples:
-  start_eq.sh                    # Launch 1 instance (raid focus)
-  start_eq.sh --multi            # Launch multibox instances from config
-  start_eq.sh --instances 4      # Launch exactly 4 instances
-```
-
-## window_manager
-
-```
-bash: warning: shell level (1000) too high, resetting to 1
-Usage: window_manager.sh <command>
-
-Manage EverQuest windows for multiboxing.
-
-Commands:
-  tile       Arrange all EQ windows in a grid layout
-  focus      Cycle focus to the next EQ window
-  list       Show all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-e: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-t       Show all detected EQ windows
-  pip        Picture-in-picture: main window large, others small
-  -h, --help Show this help
-
-Replaces ISBoxer window management on Linux using native X11 tools.
-```
-
-ces ISBoxer window management on Linux using native X11 tools.
-```
-
+_Auto-generated from `make help` output._
+
+| Command                 | Description                                                     |
+| ----------------------- | --------------------------------------------------------------- |
+| `make prereqs`          | Install system prerequisites (Wine, Vulkan, etc.)               |
+| `make install`          | Install pnpm dependencies                                       |
+| `make build`            | Compile TypeScript and Wine helper                              |
+| `make deploy`           | Full deployment (prefix + DXVK + EQ install + config)           |
+| `make launch`           | Launch a single EverQuest instance                              |
+| `make launch-multi`     | Launch multibox instances (default: 3)                          |
+| `make fix`              | Fix everything — syncs display, tiles windows or applies config |
+| `make tile`             | Tile windows — main character gets large window                 |
+| `make tile-set-main`    | Identify which window is your main character                    |
+| `make tile-grid`        | Equal grid tile (all windows same size)                         |
+| `make pip`              | Picture-in-picture layout                                       |
+| `make focus-next`       | Cycle focus to next EQ window                                   |
+| `make windows`          | List all detected EQ windows                                    |
+| `make configure`        | Apply optimized eqclient.ini settings                           |
+| `make colors`           | Apply WCAG-compliant chat color scheme                          |
+| `make layout`           | Apply 4-window chat layout (Social/Combat/Spam/Alerts)          |
+| `make layout-apply`     | Apply a layout template (TEMPLATE=name)                         |
+| `make layout-templates` | List available layout templates                                 |
+| `make maps`             | Install Good's maps (auto-download, or FILE=path/to/custom.zip) |
+| `make parser`           | Install EQLogParser DPS meter (auto-download from GitHub)       |
+| `make doctor`           | Health check — validate entire installation                     |
+| `make status`           | Show diagnostic dashboard (monitor, windows, config)            |
+| `make support-bundle`   | Generate a support bundle for troubleshooting                   |
+| `make logs`             | Tail all EQ instance logs                                       |
+| `make backup-session`   | Back up launcher login session                                  |
+| `make restore-session`  | Restore launcher session from backup                            |
+| `make clean`            | Remove build artifacts and coverage                             |
+| `make purge`            | Remove Wine prefix and all EQ data (DESTRUCTIVE)                |
+| `make help`             | Show available commands                                         |
+| `make Dev`              | targets (not shown): typecheck, lint, test, docs, stats, format |
+| `make Dry-run`          | variants: prereqs-dry, deploy-dry, configure-dry, fix-dry       |
+
+## Development Targets (hidden from help)
+
+| Command          | Description                     |
+| ---------------- | ------------------------------- |
+| `make typecheck` | TypeScript strict type checking |
+| `make lint`      | ESLint with project rules       |
+| `make test`      | Run Vitest test suite           |
+| `make format`    | Prettier formatting             |
+| `make docs`      | Generate API docs               |
+| `make stats`     | Project statistics              |

--- a/docs/eqlogparser-setup.md
+++ b/docs/eqlogparser-setup.md
@@ -1,0 +1,96 @@
+---
+title: EQLogParser Setup
+description: DPS meter and GINA-compatible trigger system for EQ on Linux
+source: scripts/install_parser.sh, scripts/install_shortcuts.sh
+updated: auto-generated
+---
+
+# EQLogParser Setup
+
+EQLogParser is a .NET 8 WPF application for DPS parsing and audio triggers.
+It runs in its own Wine prefix (`~/.wine-eqlogparser`) to avoid conflicts
+with EQ's window management settings.
+
+## Installation
+
+```bash
+make parser
+```
+
+This automatically:
+
+1. Creates a dedicated Wine prefix (`~/.wine-eqlogparser`)
+2. Installs Wine Mono (.NET support)
+3. Installs .NET 8 Desktop Runtime
+4. Installs core fonts (prevents WPF rendering crash)
+5. Disables DWM composition (prevents minimize crash)
+6. Downloads latest EQLogParser from GitHub (PiperTTS variant)
+7. Silently installs via Inno Setup
+8. Symlinks EQ directory for log access
+9. Extracts icon from .exe and pins to taskbar
+
+## First Launch
+
+1. Click the EQLogParser icon in your taskbar (bar chart icon)
+2. File → Open → navigate to `C:\EverQuest\Logs\`
+3. Select your main character's log: `eqlog_YourCharacter_server.txt`
+4. Settings → Triggers → enable **"Use Piper TTS"** (Windows TTS unavailable under Wine)
+
+## Log File Location
+
+EQ logs are at:
+
+- **Linux path:** `~/.wine-eq/drive_c/EverQuest/Logs/`
+- **Wine path (in EQLogParser):** `C:\EverQuest\Logs\`
+
+The parser prefix has a symlink to the EQ prefix's game files, so
+`C:\EverQuest\` in EQLogParser points to the actual EQ install.
+
+## GINA Compatibility
+
+EQLogParser can import GINA trigger packages (`.gtp` files):
+
+- Settings → Triggers → Import
+- Select your `.gtp` file
+- Triggers will fire with PiperTTS audio alerts
+
+## Troubleshooting
+
+### Parser won't launch
+
+Check if .NET 8 is installed:
+
+```bash
+WINEPREFIX=~/.wine-eqlogparser wine dotnet --list-runtimes
+```
+
+Should show `Microsoft.WindowsDesktop.App 8.x.x`.
+
+### Crash on minimize
+
+DWM composition should be disabled. Verify:
+
+```bash
+grep DisableComposition ~/.wine-eqlogparser/user.reg
+```
+
+Should show `"DisableComposition"="Y"`.
+
+### Can't find logs
+
+Verify the symlink exists:
+
+```bash
+ls -la ~/.wine-eqlogparser/drive_c/EverQuest
+```
+
+Should be a symlink to `~/.wine-eq/drive_c/EverQuest`.
+
+### Reinstall
+
+```bash
+make parser PARSER_FILE=  # uses --update flag
+# or manually:
+rm -rf ~/.wine-eqlogparser
+make parser
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,62 @@
+---
+title: Getting Started
+description: Quick start guide for norrath-native
+source: README.md, scripts/deploy_eq_env.sh
+updated: auto-generated
+---
+
+# Getting Started
+
+## One-Command Setup
+
+```bash
+git clone https://github.com/williamzujkowski/norrath-native.git
+cd norrath-native
+make prereqs       # Installs Wine 11, Vulkan drivers, NTSYNC
+make install       # Installs Node.js/pnpm dependencies
+make deploy        # Creates Wine prefix, installs DXVK + EQ + maps
+make doctor        # Verify installation
+make launch        # Launch EverQuest
+```
+
+## Multiboxing (3 Characters)
+
+```bash
+make launch-multi  # Launches 3 instances with stagger delay
+make tile-set-main # Identify which window is your main character
+make fix           # Tiles windows (main gets 16:9, boxes stacked right)
+```
+
+## After Dock/Undock
+
+```bash
+make fix           # Re-tiles for new monitor, applies all settings
+make status        # Diagnostic dashboard
+```
+
+## EQLogParser (DPS + Triggers)
+
+```bash
+make parser        # Auto-installs .NET 8 + EQLogParser + icon
+```
+
+First launch:
+
+1. File → Open → `C:\EverQuest\Logs\`
+2. Select your main character's log file
+3. Settings → Triggers → enable "Use Piper TTS"
+
+## Useful Commands
+
+| Command               | What it does                             |
+| --------------------- | ---------------------------------------- |
+| `make fix`            | Fix everything (display, tiling, config) |
+| `make tile`           | Re-tile windows                          |
+| `make focus-next`     | Cycle focus between EQ windows           |
+| `make doctor`         | Health check (29 checks)                 |
+| `make status`         | Diagnostic dashboard                     |
+| `make windows`        | List EQ windows                          |
+| `make configure`      | Apply/update eqclient.ini                |
+| `make colors`         | Apply chat color scheme                  |
+| `make maps`           | Install/update Good's maps               |
+| `make support-bundle` | Generate troubleshooting bundle          |

--- a/docs/multiboxing.md
+++ b/docs/multiboxing.md
@@ -1,0 +1,110 @@
+---
+title: Multiboxing Guide
+description: Running multiple EQ instances with window tiling
+source: scripts/smart_tile.sh, scripts/window_manager.sh, helpers/wine_helper.c
+updated: auto-generated
+---
+
+# Multiboxing Guide
+
+## Launch
+
+```bash
+make launch-multi  # Launches 3 instances (configurable in norrath-native.yaml)
+```
+
+Each instance gets:
+
+- Staggered startup (5s default) to avoid GPU initialization races
+- Background priority for box characters (nice -n 10 + ionice)
+- Separate log file (`~/.local/share/norrath-native/eq-instance-N.log`)
+
+## Window Tiling
+
+```bash
+make fix           # Syncs display + tiles windows
+make tile          # Re-tile only (main gets large window)
+make tile-grid     # Equal grid (all same size)
+make pip           # Picture-in-picture layout
+```
+
+### Ultrawide Support
+
+On ultrawide monitors (21:9), the main window is clamped to 16:9
+(2560x1440 on a 3440x1440 display). Box windows get the remaining space.
+
+### Setting Your Main Character
+
+The first time you tile, you need to tell norrath-native which window
+is your main character:
+
+```bash
+make tile-set-main
+```
+
+This flashes each window and asks you to pick a number. The mapping
+is saved to `~/.local/share/norrath-native/hwnd-character-map` and
+persists across sessions.
+
+Or set it in `norrath-native.yaml`:
+
+```yaml
+main_character: Grenlan
+```
+
+## Focus Cycling
+
+```bash
+make focus-next    # Cycle focus to the next EQ window
+```
+
+Uses Wine's `SetForegroundWindow` API for reliable focus switching.
+
+## Architecture
+
+Each EQ instance runs as a native XWayland top-level window (no Wine
+virtual desktop). This provides:
+
+- Native GNOME/Mutter click-to-focus
+- Proper window decorations
+- Normal alt-tab behavior
+- No X11 stacking bugs
+
+Window tiling uses `wine_helper.exe` (MinGW-compiled C program) which
+calls Win32 APIs (`EnumWindows`, `SetWindowPos`, `SetForegroundWindow`)
+through Wine. This is more reliable than X11 tools (xdotool was removed
+after causing Wine focus routing corruption).
+
+## Configuration
+
+```yaml
+# norrath-native.yaml
+instances: 1 # Single launch count
+multibox_instances: 3 # make launch-multi count
+stagger_delay: 5 # Seconds between instance launches
+main_character: Grenlan # Gets the large window
+profile: raid # Performance profile for boxes
+```
+
+## Troubleshooting
+
+### Windows not tiling
+
+```bash
+make status        # Check window detection
+make windows       # List detected EQ windows
+```
+
+### eqclient.ini overwritten on exit
+
+Settings are protected: `make configure` sets eqclient.ini to read-only
+(444) after applying settings, preventing the multibox exit race condition.
+
+### Performance
+
+```bash
+make doctor        # Check NTSYNC status (kernel-level Wine perf)
+```
+
+NTSYNC (kernel 6.14+) significantly reduces CPU overhead when running
+multiple Wine instances. Enabled by `make prereqs`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,87 @@
+---
+title: Troubleshooting
+description: Common issues and fixes for norrath-native
+source: scripts/doctor.sh, src/doctor.ts
+updated: auto-generated
+---
+
+# Troubleshooting
+
+Run diagnostics first:
+
+```bash
+make doctor        # 29-point health check
+make status        # Display/window dashboard
+make support-bundle # Generate debug bundle for sharing
+```
+
+## Common Issues
+
+### "not responding" dialog on zone load
+
+GNOME shows this when EQ blocks its main thread during zone loads.
+Workaround (applied automatically):
+
+```bash
+gsettings set org.gnome.mutter check-alive-timeout 60000
+```
+
+### Launcher shows black box
+
+CEF (Chromium) needs software rendering. Applied automatically via
+`--disable-gpu` flag. If it still happens:
+
+```bash
+WINEPREFIX=~/.wine-eq wine LaunchPad.exe --disable-gpu
+```
+
+### Can't click on a window after tiling
+
+Run `make fix` to re-tile. If the issue persists, check `make status`
+for window positions.
+
+### Wrong character in main window
+
+```bash
+make tile-set-main  # Re-identify which window is your main
+make fix            # Re-tile with correct mapping
+```
+
+### Settings lost after closing EQ
+
+eqclient.ini is set read-only after `make configure` to prevent the
+multibox exit race condition. To update settings:
+
+```bash
+make configure      # Temporarily makes writable, applies, re-locks
+```
+
+### Wine version too old
+
+```bash
+make prereqs        # Upgrades to Wine 11 from WineHQ
+make doctor         # Verify: should show "wine 11.x"
+```
+
+### DXVK / Vulkan errors
+
+```bash
+vulkaninfo | grep deviceName  # Should show your GPU
+make doctor                   # Check DXVK DLL status
+```
+
+### EQLogParser crashes
+
+See [EQLogParser Setup](eqlogparser-setup.md#troubleshooting).
+
+## Support Bundle
+
+```bash
+make support-bundle
+```
+
+Generates `norrath-native-support.tar.gz` containing:
+
+- Doctor check results (JSON)
+- Instance logs
+- Deploy state


### PR DESCRIPTION
## Summary
Complete documentation overhaul with YAML frontmatter linking each doc to its source.

### New docs
| Document | Description |
|----------|-------------|
| [Getting Started](docs/getting-started.md) | One-command setup, first launch, multibox quick start |
| [Multiboxing](docs/multiboxing.md) | Window tiling, focus cycling, architecture, config |
| [EQLogParser Setup](docs/eqlogparser-setup.md) | Install, GINA compat, log paths, troubleshooting |
| [Troubleshooting](docs/troubleshooting.md) | Common issues with solutions |
| [README](docs/README.md) | Documentation index |

### Updated docs
- `commands.md` — regenerated from current Makefile
- `checks.md` — all 29 checks categorized (System, Prefix, DXVK, EQ, State)

### Frontmatter
Every doc has YAML frontmatter:
```yaml
---
title: EQLogParser Setup
description: DPS meter and GINA-compatible trigger system
source: scripts/install_parser.sh, scripts/install_shortcuts.sh
updated: auto-generated
---
```

## Test plan
- [x] 172 tests pass
- [x] Stats clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)