### PR TITLE
fix: remove Managed=N/Decorated=N — keyboard focus goes to terminal

### DIFF
--- a/scripts/deploy_eq_env.sh
+++ b/scripts/deploy_eq_env.sh
@@ -282,14 +282,11 @@ tune_wine_registry() {
         'HKEY_CURRENT_USER\Software\Wine\X11 Driver' \
         /v GrabFullscreen /d Y /f
 
-    # Disable WM decorations — prevents compositor resize grips
-    # from interfering with window edge clicks
-    run env WINEPREFIX="${PREFIX}" "${NN_WINE_CMD}" reg add \
-        'HKEY_CURRENT_USER\Software\Wine\X11 Driver' \
-        /v Decorated /d N /f
-    run env WINEPREFIX="${PREFIX}" "${NN_WINE_CMD}" reg add \
-        'HKEY_CURRENT_USER\Software\Wine\X11 Driver' \
-        /v Managed /d N /f
+    # NOTE: Do NOT set Managed=N or Decorated=N here.
+    # These were used with the Wine virtual desktop (removed in PR #78)
+    # to prevent compositor resize grip issues. With native XWayland
+    # windows, Managed=N causes WM_HINTS input=false which prevents
+    # GNOME from giving keyboard focus to EQ windows on click.
 
     # Disable DWM desktop composition — WPF apps (EQLogParser) crash on
     # minimize when DwmIsCompositionEnabled returns true, because Wine's


### PR DESCRIPTION
## Summary
Text typed after clicking EQ window goes to the terminal instead of EQ.

### Root cause
`Managed=N` in Wine registry makes Wine create override-redirect X11 windows with `WM_HINTS input=false`. GNOME doesn't manage these windows, so click-to-focus doesn't transfer keyboard input.

```
WM_HINTS(WM_HINTS):
    Client accepts input or input focus: False  ← this is the bug
```

### Why it was there
Added for Wine virtual desktop compositor resize grip workaround (PR #78 era). Virtual desktop was removed but the settings persisted.

### Fix
Remove `Managed=N` and `Decorated=N` from deploy. Native XWayland windows work correctly with GNOME's default window management.

Applied to live registry — EQ needs restart to pick up the change.

## Test plan
- [x] Registry cleared
- [x] 172 tests pass, ShellCheck clean
- [ ] After EQ restart: clicking EQ window gives keyboard focus
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)