### PR TITLE
feat: enable HH:MM:SS timestamps on all chat windows by default

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -256,6 +256,26 @@ export function generateChannelMapEntries(): Record<string, string> {
   for (const [id, windowIndex] of Object.entries(CHANNEL_MAP)) {
     entries[`ChannelMap${id}`] = String(windowIndex);
   }
+
+  // Enable HH:MM:SS timestamps on all chat windows by default.
+  // Format: 0=off, 1=HH:MM:SS, 2=HH.MM, 3=MM.SS
+  // Timestamps are essential for log parsing, raid timing, and debugging.
+  for (let w = 0; w < WINDOW_NAMES.length; w++) {
+    entries[`ChatWindow${String(w)}_TimestampFormat`] = "1";
+    entries[`ChatWindow${String(w)}_TimestampMatchChatColor`] = "1";
+  }
+
+  // Set window names
+  for (let w = 0; w < WINDOW_NAMES.length; w++) {
+    const name = WINDOW_NAMES[w];
+    if (name !== undefined) {
+      entries[`ChatWindow${String(w)}_Name`] = name;
+    }
+  }
+
+  // Set NumWindows
+  entries["NumWindows"] = String(WINDOW_NAMES.length);
+
   return entries;
 }
 

--- a/tests/layout.test.ts
+++ b/tests/layout.test.ts
@@ -83,23 +83,46 @@ describe("generateChannelMapEntries", () => {
     expect(entries["ChannelMap106"]).toBeDefined();
   });
 
-  it("produces 107 entries", () => {
+  it("produces 107 channel entries plus window config", () => {
     const entries = generateChannelMapEntries();
-    expect(Object.keys(entries).length).toBe(107);
+    const channelEntries = Object.keys(entries).filter((k) =>
+      k.startsWith("ChannelMap"),
+    );
+    expect(channelEntries.length).toBe(107);
+    // Also includes timestamps, window names, NumWindows
+    expect(Object.keys(entries).length).toBeGreaterThan(107);
   });
 
-  it("all keys follow ChannelMapN format", () => {
+  it("all channel keys follow ChannelMapN format", () => {
     const entries = generateChannelMapEntries();
     for (const key of Object.keys(entries)) {
-      expect(key).toMatch(/^ChannelMap\d+$/);
+      if (key.startsWith("ChannelMap")) {
+        expect(key).toMatch(/^ChannelMap\d+$/);
+      }
     }
   });
 
-  it("values are string representations of window indices", () => {
+  it("channel values are string window indices", () => {
     const entries = generateChannelMapEntries();
-    for (const [, value] of Object.entries(entries)) {
-      expect(value).toMatch(/^[0-3]$/);
+    for (const [key, value] of Object.entries(entries)) {
+      if (key.startsWith("ChannelMap")) {
+        expect(value).toMatch(/^[0-3]$/);
+      }
     }
+  });
+
+  it("enables HH:MM:SS timestamps on all windows", () => {
+    const entries = generateChannelMapEntries();
+    expect(entries["ChatWindow0_TimestampFormat"]).toBe("1");
+    expect(entries["ChatWindow1_TimestampFormat"]).toBe("1");
+    expect(entries["ChatWindow2_TimestampFormat"]).toBe("1");
+    expect(entries["ChatWindow3_TimestampFormat"]).toBe("1");
+  });
+
+  it("sets window names", () => {
+    const entries = generateChannelMapEntries();
+    expect(entries["ChatWindow0_Name"]).toBe("Social");
+    expect(entries["NumWindows"]).toBe("4");
   });
 
   it("Tell channel maps to Social window", () => {


### PR DESCRIPTION
## Summary
Chat timestamps now enabled automatically on all 4 windows when applying layout.

### What's added to layout:apply
```ini
ChatWindow0_TimestampFormat=1     # HH:MM:SS
ChatWindow0_TimestampMatchChatColor=1
ChatWindow1_TimestampFormat=1
ChatWindow1_TimestampMatchChatColor=1
ChatWindow2_TimestampFormat=1
ChatWindow2_TimestampMatchChatColor=1
ChatWindow3_TimestampFormat=1
ChatWindow3_TimestampMatchChatColor=1
ChatWindow0_Name=Social
ChatWindow1_Name=Combat
ChatWindow2_Name=Spam
ChatWindow3_Name=Alerts & Loot
NumWindows=4
```

### Why
- EQ defaults timestamps to off
- Timestamps are essential for EQLogParser correlation, raid timing, and troubleshooting
- HH:MM:SS is the most useful format (matches log file timestamps)
- Color-matched timestamps don't add visual clutter

### Tests
180 tests (was 178): added timestamp format and window name assertions.

## Test plan
- [x] 180 tests pass
- [x] Lint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)