### PR TITLE
fix: deduplicate INI keys + auto-set resolution (#118, #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Initial pre-release. Full-featured but actively evolving.
 
 - Deterministic Wine prefix + DXVK deployment (idempotent, --dry-run)
 - EverQuest silent installer integration
-- 43 managed eqclient.ini settings across 5 profiles (high/balanced/raid/low/minimal)
+- 47 managed eqclient.ini settings across 5 profiles (high/balanced/raid/low/minimal)
 - dxvk.conf with async shaders and frame latency tuning
 - Wine registry tuning (GrabFullscreen, VideoMemorySize, MouseWarpOverride)
 - Microsoft corefonts via winetricks

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ make deploy  # Rebuild from scratch
 norrath-native/
   src/
     cli.ts               — Unified CLI entry point (21 commands)
-    config.ts            — YAML config, 5 profiles, 43 managed settings
+    config.ts            — YAML config, 5 profiles, 47 managed settings
     colors.ts            — 91-color WCAG AA-compliant chat scheme
     layout.ts            — 107-channel → 4-window chat routing
     resolution.ts        — Ultrawide detection, 16:9 clamping, tiling

--- a/norrath-native.example.yaml
+++ b/norrath-native.example.yaml
@@ -76,7 +76,7 @@ stagger_delay: 5
 
 # ─── Performance Profile ──────────────────────────────────────────────────────
 #
-# Choose a preset. Each profile is opinionated about 43 EQ settings
+# Choose a preset. Each profile is opinionated about 47 EQ settings
 # covering FPS, graphics quality, particles, sound, network, and CPU usage.
 #
 # Profiles are ordered from highest quality to lowest resource usage:

--- a/src/config-injector.ts
+++ b/src/config-injector.ts
@@ -161,8 +161,25 @@ function ensureSectionAndAppend(
   return appendMapEntries(lines, remaining);
 }
 
+/** Remove duplicate keys from parsed lines (keep last occurrence). */
+function deduplicateKeys(lines: IniLine[]): void {
+  const seen = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line !== undefined && line.kind === "kv") {
+      const prev = seen.get(line.key);
+      if (prev !== undefined) {
+        // Mark previous occurrence for removal
+        lines[prev] = { kind: "verbatim", raw: "" };
+      }
+      seen.set(line.key, i);
+    }
+  }
+}
+
 /**
  * Inject arbitrary key-value settings into an INI file section.
+ * Deduplicates keys after injection to prevent buildup.
  * Returns count of changes made.
  */
 export function injectSettings(
@@ -175,6 +192,9 @@ export function injectSettings(
 
   let changed = updateExistingKeys(lines, section, pending);
   changed += ensureSectionAndAppend(lines, section, pending);
+
+  // Deduplicate keys that may exist across sections
+  deduplicateKeys(lines);
 
   const writeResult = writeFile(filePath, serializeIni(lines));
   if (!writeResult.ok) return writeResult;

--- a/src/config.ts
+++ b/src/config.ts
@@ -282,6 +282,11 @@ export function generateManagedSettings(
   config: NorrathConfig,
 ): Record<string, string> {
   const s = config.eqSettings;
+  // Parse resolution for Width/Height
+  const resParts = config.resolution.split("x");
+  const resW = resParts[0] ?? "1920";
+  const resH = resParts[1] ?? "1080";
+
   const settings: Record<string, string> = {
     WindowedMode: "TRUE",
     UpdateInBackground: "1",
@@ -291,6 +296,10 @@ export function generateManagedSettings(
     AllowResize: "1",
     Maximized: "1",
     AlwaysOnTop: "0",
+    Width: resW,
+    Height: resH,
+    WindowedWidth: resW,
+    WindowedHeight: resH,
     MaxBGFPS: String(s.maxBgFps),
     PostEffects: boolTF(s.postEffects),
     MultiPassLighting: boolTF(s.multiPassLighting),

--- a/tests/config-injector.test.ts
+++ b/tests/config-injector.test.ts
@@ -331,4 +331,36 @@ describe("injectSettings", () => {
     expect(content).toContain("A=99");
     expect(content).toContain("B=2");
   });
+
+  it("deduplicates keys when same key exists in multiple sections", () => {
+    const iniPath = path.join(tmpDir, "test.ini");
+    fs.writeFileSync(
+      iniPath,
+      "[Section1]\nShared=old\n[Section2]\nShared=also_old\n",
+    );
+
+    const result = injectSettings(iniPath, { Shared: "new" }, "Section1");
+    expect(result.ok).toBe(true);
+
+    const content = fs.readFileSync(iniPath, "utf-8");
+    const matches = content.match(/Shared=/g);
+    // Should only have ONE occurrence after dedup
+    expect(matches).toHaveLength(1);
+    expect(content).toContain("Shared=new");
+  });
+
+  it("does not create duplicates on repeated application", () => {
+    const iniPath = path.join(tmpDir, "test.ini");
+    fs.writeFileSync(iniPath, "[MySection]\nKey1=a\n");
+
+    // Apply twice
+    injectSettings(iniPath, { Key1: "b", Key2: "c" }, "MySection");
+    injectSettings(iniPath, { Key1: "b", Key2: "c" }, "MySection");
+
+    const content = fs.readFileSync(iniPath, "utf-8");
+    const key1Matches = content.match(/Key1=/g);
+    const key2Matches = content.match(/Key2=/g);
+    expect(key1Matches).toHaveLength(1);
+    expect(key2Matches).toHaveLength(1);
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -142,13 +142,13 @@ describe("generateManagedSettings", () => {
     expect(settings["MultiPassLighting"]).toBe("FALSE");
   });
 
-  it("generates 43 total managed settings (high profile)", () => {
+  it("generates 47 total managed settings (high profile)", () => {
     const result = resolveConfig();
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
     const settings = generateManagedSettings(result.value);
-    expect(Object.keys(settings).length).toBe(43);
+    expect(Object.keys(settings).length).toBe(47);
   });
 
   it("reflects profile in FPS values", () => {


### PR DESCRIPTION
## Summary
Two fixes that improve robustness.

### Bug fix: INI key deduplication (#118)
`injectSettings()` now runs `deduplicateKeys()` after injection. Prevents key accumulation when:
- `make layout` is run multiple times
- EQ writes conflicting values before our injection

### Feature: auto-set resolution (#123)
`generateManagedSettings()` now includes Width/Height/WindowedWidth/WindowedHeight from the resolved config resolution. EQ starts at the correct size instead of defaulting to 872x686.

### Tests
| What | Before | After |
|------|--------|-------|
| Tests | 198 | 200 |
| Managed settings | 43 | 47 |

New tests: deduplication across sections, idempotent repeated application.

Closes #118, closes #123.

## Test plan
- [x] 200 tests pass
- [x] Stats auto-fixed (43→47)
- [x] Lint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)