### PR TITLE
feat: integration test suite (200 → 211 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ norrath-native/
     metadata.ts          — Programmatic project stats (self-documenting)
     types/interfaces.ts  — Core TypeScript contracts
   scripts/               — 20 bash scripts (thin system wrappers)
-  tests/                 — 9 test files
+  tests/                 — 10 test files
   layouts/               — 4 window layout templates
   helpers/wine_helper.c  — Wine API helper (SetWindowPos, HWND mapping)
   Makefile               — 29 targets (make help)

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Integration tests — validate make targets and CLI commands
+ * work end-to-end as a subprocess.
+ *
+ * These tests run actual commands and verify output/exit codes.
+ * They don't require Wine or EQ to be installed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname ?? "", "..");
+
+function run(cmd: string): { stdout: string; exitCode: number } {
+  try {
+    const stdout = execSync(cmd, {
+      cwd: ROOT,
+      encoding: "utf-8",
+      timeout: 30_000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { stdout, exitCode: 0 };
+  } catch (e: unknown) {
+    const err = e as { stdout?: string; status?: number };
+    return { stdout: err.stdout ?? "", exitCode: err.status ?? 1 };
+  }
+}
+
+describe("make targets (smoke tests)", () => {
+  it("make help exits 0 and lists commands", () => {
+    const { stdout, exitCode } = run("make help");
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("fix");
+    expect(stdout).toContain("doctor");
+    expect(stdout).toContain("launch");
+  });
+
+  it("make build exits 0", () => {
+    const { exitCode } = run("make build");
+    expect(exitCode).toBe(0);
+  });
+
+  it("make typecheck exits 0", () => {
+    const { exitCode } = run("make typecheck");
+    expect(exitCode).toBe(0);
+  });
+
+  it("make lint exits 0", () => {
+    const { exitCode } = run("make lint");
+    expect(exitCode).toBe(0);
+  });
+
+  it("make format-check exits 0", () => {
+    const { exitCode } = run("make format-check");
+    expect(exitCode).toBe(0);
+  });
+
+  it("make stats exits 0 (docs match source)", () => {
+    const { exitCode } = run("make stats");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("CLI metadata consistency", () => {
+  const CLI = join(ROOT, "dist", "cli.js");
+
+  it("metadata colors count matches colors:scheme output", () => {
+    const meta = JSON.parse(
+      execSync(`node ${CLI} metadata`, { encoding: "utf-8" }),
+    ) as { colors: { count: number } };
+    const scheme = JSON.parse(
+      execSync(`node ${CLI} colors:scheme`, { encoding: "utf-8" }),
+    ) as Record<string, unknown>;
+    expect(meta.colors.count).toBe(Object.keys(scheme).length);
+  });
+
+  it("metadata channels count matches layout:channels output", () => {
+    const meta = JSON.parse(
+      execSync(`node ${CLI} metadata`, { encoding: "utf-8" }),
+    ) as { channels: { count: number } };
+    const channels = JSON.parse(
+      execSync(`node ${CLI} layout:channels`, { encoding: "utf-8" }),
+    ) as Record<string, unknown>;
+    expect(meta.channels.count).toBe(Object.keys(channels).length);
+  });
+
+  it("metadata settings count matches config:settings output", () => {
+    const meta = JSON.parse(
+      execSync(`node ${CLI} metadata`, { encoding: "utf-8" }),
+    ) as { managedSettings: { count: number } };
+    const settings = JSON.parse(
+      execSync(`node ${CLI} config:settings`, { encoding: "utf-8" }),
+    ) as Record<string, unknown>;
+    expect(meta.managedSettings.count).toBe(Object.keys(settings).length);
+  });
+
+  it("config:settings includes resolution keys", () => {
+    const settings = JSON.parse(
+      execSync(`node ${CLI} config:settings`, { encoding: "utf-8" }),
+    ) as Record<string, string>;
+    expect(settings).toHaveProperty("Width");
+    expect(settings).toHaveProperty("Height");
+    expect(settings).toHaveProperty("WindowedWidth");
+    expect(settings).toHaveProperty("WindowedHeight");
+  });
+});
+
+describe("shellcheck compliance", () => {
+  it("all bash scripts pass shellcheck", () => {
+    const { exitCode } = run("shellcheck --exclude=SC1091 scripts/*.sh 2>&1");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds 11 integration tests that validate the build pipeline, CLI consistency, and bash script quality. Closes #111.

### New tests
| Category | Tests | What's validated |
|----------|-------|-----------------|
| Make targets | 6 | help, build, typecheck, lint, format-check, stats all exit 0 |
| CLI consistency | 4 | Metadata counts match actual command output (colors, channels, settings, resolution keys) |
| ShellCheck | 1 | All 20 bash scripts pass shellcheck |

### Why these matter
- Make target tests catch build/lint regressions before they reach CI
- CLI consistency tests catch when data counts drift between metadata and actual output
- ShellCheck test catches bash syntax errors automatically

**Tests: 200 → 211**

## Test plan
- [x] 211 tests pass
- [x] Lint clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)