### PR TITLE
feat(doctor): add EQ patch compatibility detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ src/config.ts          — YAML config parsing, profiles, managed settings
 src/colors.ts          — 91-color WCAG-compliant chat color scheme
 src/layout.ts          — 107-channel chat window routing (4-window layout)
 src/resolution.ts      — Ultrawide detection, 16:9 clamping, viewport, tiling
-src/doctor.ts          — 29 structured health checks with JSON output
+src/doctor.ts          — 30 structured health checks with JSON output
 src/config-injector.ts — Idempotent INI file manipulation
 src/dxvk-resolver.ts   — GitHub API DXVK release resolver
 scripts/*.sh           — Thin bash wrappers (call cli_cmd for TS logic)

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ norrath-native/
     colors.ts            — 91-color WCAG AA-compliant chat scheme
     layout.ts            — 107-channel → 4-window chat routing
     resolution.ts        — Ultrawide detection, 16:9 clamping, tiling
-    doctor.ts            — 29 structured health checks (JSON output)
+    doctor.ts            — 30 structured health checks (JSON output)
     config-injector.ts   — Idempotent INI file manipulation
     dxvk-resolver.ts     — GitHub API DXVK release resolver
     metadata.ts          — Programmatic project stats (self-documenting)

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -51,6 +51,7 @@ _Run `make doctor` to see current status. Run `make doctor --json` for machine-r
 | `EQ_REMEMBER_ME` | Remember Me cookie database      |
 | `EQ_MAPS`        | Good's maps installed            |
 | `EQ_DXVK_CONF`   | DXVK config (async shaders)      |
+| `EQ_PATCH_STATE` | EQ patch state tracked           |
 | `EQ_PARSER`      | EQLogParser installed            |
 
 ## Deploy State

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ First launch:
 | `make fix`            | Fix everything (display, tiling, config) |
 | `make tile`           | Re-tile windows                          |
 | `make focus-next`     | Cycle focus between EQ windows           |
-| `make doctor`         | Health check (29 checks)                 |
+| `make doctor`         | Health check (30 checks)                 |
 | `make status`         | Diagnostic dashboard                     |
 | `make windows`        | List EQ windows                          |
 | `make configure`      | Apply/update eqclient.ini                |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,7 +10,7 @@ updated: auto-generated
 Run diagnostics first:
 
 ```bash
-make doctor        # 29-point health check
+make doctor        # 30-point health check
 make status        # Display/window dashboard
 make support-bundle # Generate debug bundle for sharing
 ```

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- cohesive module: all health checks belong together (governance: 400-600 OK) */
 /**
  * Doctor module — health check system for norrath-native.
  *
@@ -8,7 +9,7 @@
  * @module doctor
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { join } from "node:path";
 
@@ -371,6 +372,57 @@ function eqCoreChecks(eqDir: string): Check[] {
   ];
 }
 
+/** Check if saved EQ exe size matches current. */
+function checkPatchState(eqExe: string): CheckResult {
+  const id = "EQ_PATCH_STATE";
+  if (!existsSync(eqExe)) {
+    return {
+      id,
+      status: "warn",
+      message: "eqgame.exe not found",
+      fix: "let patcher finish",
+    };
+  }
+  const size = statSync(eqExe).size;
+  const stateFile = join(
+    process.env["HOME"] ?? "/tmp",
+    ".local/share/norrath-native/state.json",
+  );
+  if (existsSync(stateFile)) {
+    try {
+      const state = JSON.parse(readFileSync(stateFile, "utf-8")) as Record<
+        string,
+        unknown
+      >;
+      const saved = state["eq_exe_size"] as number | undefined;
+      if (saved !== undefined && saved !== size) {
+        return {
+          id,
+          status: "warn",
+          message: "EQ may have been patched (eqgame.exe changed)",
+          fix: "run: make fix",
+        };
+      }
+    } catch {
+      /* state unreadable */
+    }
+  }
+  return {
+    id,
+    status: "pass",
+    message: `eqgame.exe: ${String(Math.round(size / 1024 / 1024))}MB`,
+  };
+}
+
+/** Detect if EQ has been patched since last deploy. */
+function createPatchCheck(eqDir: string): Check {
+  return {
+    id: "EQ_PATCH_STATE",
+    name: "EQ patch state tracked",
+    run: () => checkPatchState(join(eqDir, "eqgame.exe")),
+  };
+}
+
 function eqExtrasChecks(_prefix: string, eqDir: string): Check[] {
   return [
     createFileCheck(
@@ -397,6 +449,7 @@ function eqExtrasChecks(_prefix: string, eqDir: string): Check[] {
       join(eqDir, "dxvk.conf"),
       "run: make deploy",
     ),
+    createPatchCheck(eqDir),
     createFileCheck(
       "EQ_PARSER",
       "EQLogParser installed",

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -316,7 +316,7 @@ describe("buildDefaultChecks", () => {
   it("returns an array of checks", () => {
     const checks = buildDefaultChecks("/tmp/fake-prefix");
     expect(Array.isArray(checks)).toBe(true);
-    expect(checks.length).toBe(29);
+    expect(checks.length).toBe(30);
   });
 
   it("all checks have id and name", () => {


### PR DESCRIPTION
## Summary
- Adds `EQ_PATCH_STATE` doctor check that detects if `eqgame.exe` has changed since last deploy
- Compares current file size against `state.json` record, warns user to run `make fix`
- 30 health checks total (was 29)
- Updated docs, tests, and AGENTS.md

Closes #134

## Test plan
- [x] `pnpm run test:run` — 211 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — compiles
- [x] Stats verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)