### PR TITLE
feat: add update checker for DXVK and Wine versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ norrath-native/
     metadata.ts          — Programmatic project stats (self-documenting)
     types/interfaces.ts  — Core TypeScript contracts
   scripts/               — 20 bash scripts (thin system wrappers)
-  tests/                 — 10 test files
+  tests/                 — 11 test files
   layouts/               — 4 window layout templates
   helpers/wine_helper.c  — Wine API helper (SetWindowPos, HWND mapping)
   Makefile               — 29 targets (make help)

--- a/src/update-checker.ts
+++ b/src/update-checker.ts
@@ -1,0 +1,183 @@
+/**
+ * Update checker — compares installed versions against latest available.
+ *
+ * Checks DXVK (via GitHub API) and Wine (via version string comparison)
+ * against deployed state. Non-intrusive: returns status only, never
+ * auto-updates.
+ *
+ * @module update-checker
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import {
+  filterStableReleases,
+  DXVK_RELEASES_URL,
+  meetsMinimumVersion,
+  type FetchFn,
+} from "./dxvk-resolver.js";
+import { MIN_WINE_VERSION } from "./types/interfaces.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UpdateStatus {
+  component: "dxvk" | "wine";
+  status: "up-to-date" | "update-available" | "unknown" | "error";
+  installed?: string;
+  latest?: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub release shape (minimal subset)
+// ---------------------------------------------------------------------------
+
+interface GitHubRelease {
+  tag_name: string;
+  draft: boolean;
+  prerelease: boolean;
+  assets: { name: string; browser_download_url: string }[];
+}
+
+// ---------------------------------------------------------------------------
+// DXVK update check
+// ---------------------------------------------------------------------------
+
+/** Fetch the latest stable DXVK version string from GitHub. */
+async function fetchLatestDxvkVersion(
+  fetchFn: FetchFn,
+): Promise<{ version: string } | { error: string }> {
+  const response = await fetchFn(DXVK_RELEASES_URL, {
+    headers: { Accept: "application/vnd.github.v3+json" },
+  });
+  if (!response.ok) {
+    return { error: `GitHub API returned HTTP ${String(response.status)}` };
+  }
+  const body: unknown = await response.json();
+  if (!Array.isArray(body)) {
+    return { error: "Unexpected API response shape" };
+  }
+  const stable = filterStableReleases(body as GitHubRelease[]);
+  const latestRelease = stable[0];
+  if (latestRelease === undefined) {
+    return { error: "No stable DXVK releases found" };
+  }
+  return { version: latestRelease.tag_name.replace(/^v/, "") };
+}
+
+/** Compare installed vs latest DXVK version. */
+function compareDxvkVersions(installed: string, latest: string): UpdateStatus {
+  if (meetsMinimumVersion(installed, latest)) {
+    return {
+      component: "dxvk",
+      status: "up-to-date",
+      installed,
+      latest,
+      message: `DXVK ${installed} is current`,
+    };
+  }
+  return {
+    component: "dxvk",
+    status: "update-available",
+    installed,
+    latest,
+    message: `DXVK ${latest} available (installed: ${installed})`,
+  };
+}
+
+/**
+ * Check if DXVK has a newer stable release than what's deployed.
+ *
+ * Reads the installed version from state.json, queries GitHub for latest.
+ */
+export async function checkDxvkUpdate(
+  stateFilePath: string,
+  fetchFn: FetchFn,
+): Promise<UpdateStatus> {
+  const installed = readDxvkVersion(stateFilePath);
+  if (installed === undefined) {
+    return {
+      component: "dxvk",
+      status: "unknown",
+      message: "No deployed DXVK version found in state file",
+    };
+  }
+
+  try {
+    const result = await fetchLatestDxvkVersion(fetchFn);
+    if ("error" in result) {
+      return {
+        component: "dxvk",
+        status: "error",
+        installed,
+        message: result.error,
+      };
+    }
+    return compareDxvkVersions(installed, result.version);
+  } catch {
+    return {
+      component: "dxvk",
+      status: "error",
+      installed,
+      message: "Failed to check DXVK updates",
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Wine update check (local only, no network)
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if installed Wine version meets the minimum requirement.
+ *
+ * @param versionString - Output of `wine64 --version`, e.g. "wine-11.5"
+ */
+export function checkWineUpdate(versionString: string): UpdateStatus {
+  const match = /wine-(\d+\.\d+)/.exec(versionString);
+  if (!match || match[1] === undefined) {
+    return {
+      component: "wine",
+      status: "unknown",
+      message: "Could not parse Wine version",
+    };
+  }
+
+  const installed = match[1];
+  if (meetsMinimumVersion(installed, MIN_WINE_VERSION)) {
+    return {
+      component: "wine",
+      status: "up-to-date",
+      installed,
+      latest: MIN_WINE_VERSION,
+      message: `Wine ${installed} meets minimum (${MIN_WINE_VERSION})`,
+    };
+  }
+
+  return {
+    component: "wine",
+    status: "update-available",
+    installed,
+    latest: MIN_WINE_VERSION,
+    message: `Wine ${installed} is below minimum ${MIN_WINE_VERSION}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readDxvkVersion(stateFilePath: string): string | undefined {
+  if (!existsSync(stateFilePath)) return undefined;
+  try {
+    const state = JSON.parse(readFileSync(stateFilePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    const version = state["dxvk_version"];
+    return typeof version === "string" ? version : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/update-checker.test.ts
+++ b/tests/update-checker.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { checkDxvkUpdate, checkWineUpdate } from "../src/update-checker.js";
+
+describe("checkDxvkUpdate", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `nn-update-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns up-to-date when installed matches latest", async () => {
+    const stateFile = join(tempDir, "state.json");
+    writeFileSync(stateFile, JSON.stringify({ dxvk_version: "2.5.3" }));
+    const fakeFetch = makeFakeFetch([
+      {
+        tag_name: "v2.5.3",
+        draft: false,
+        prerelease: false,
+        assets: [tarball("2.5.3")],
+      },
+    ]);
+    const result = await checkDxvkUpdate(stateFile, fakeFetch);
+    expect(result.status).toBe("up-to-date");
+    expect(result.installed).toBe("2.5.3");
+    expect(result.latest).toBe("2.5.3");
+  });
+
+  it("returns update-available when newer version exists", async () => {
+    const stateFile = join(tempDir, "state.json");
+    writeFileSync(stateFile, JSON.stringify({ dxvk_version: "2.4.0" }));
+    const fakeFetch = makeFakeFetch([
+      {
+        tag_name: "v2.5.3",
+        draft: false,
+        prerelease: false,
+        assets: [tarball("2.5.3")],
+      },
+      {
+        tag_name: "v2.4.0",
+        draft: false,
+        prerelease: false,
+        assets: [tarball("2.4.0")],
+      },
+    ]);
+    const result = await checkDxvkUpdate(stateFile, fakeFetch);
+    expect(result.status).toBe("update-available");
+    expect(result.installed).toBe("2.4.0");
+    expect(result.latest).toBe("2.5.3");
+  });
+
+  it("returns unknown when state file missing", async () => {
+    const fakeFetch = makeFakeFetch([]);
+    const result = await checkDxvkUpdate(
+      join(tempDir, "nonexistent.json"),
+      fakeFetch,
+    );
+    expect(result.status).toBe("unknown");
+  });
+
+  it("returns error when API fails", async () => {
+    const stateFile = join(tempDir, "state.json");
+    writeFileSync(stateFile, JSON.stringify({ dxvk_version: "2.4.0" }));
+    const fakeFetch = makeFakeFetchError(500);
+    const result = await checkDxvkUpdate(stateFile, fakeFetch);
+    expect(result.status).toBe("error");
+  });
+
+  it("skips draft and prerelease versions", async () => {
+    const stateFile = join(tempDir, "state.json");
+    writeFileSync(stateFile, JSON.stringify({ dxvk_version: "2.4.0" }));
+    const fakeFetch = makeFakeFetch([
+      {
+        tag_name: "v2.6.0-rc1",
+        draft: false,
+        prerelease: true,
+        assets: [tarball("2.6.0-rc1")],
+      },
+      {
+        tag_name: "v2.5.0",
+        draft: true,
+        prerelease: false,
+        assets: [tarball("2.5.0")],
+      },
+      {
+        tag_name: "v2.4.0",
+        draft: false,
+        prerelease: false,
+        assets: [tarball("2.4.0")],
+      },
+    ]);
+    const result = await checkDxvkUpdate(stateFile, fakeFetch);
+    expect(result.status).toBe("up-to-date");
+    expect(result.latest).toBe("2.4.0");
+  });
+});
+
+describe("checkWineUpdate", () => {
+  it("returns up-to-date when installed >= minimum", () => {
+    const result = checkWineUpdate("wine-11.5");
+    expect(result.status).toBe("up-to-date");
+  });
+
+  it("returns update-available when below minimum", () => {
+    const result = checkWineUpdate("wine-9.0");
+    expect(result.status).toBe("update-available");
+    expect(result.installed).toBe("9.0");
+  });
+
+  it("handles wine64 version string", () => {
+    const result = checkWineUpdate("wine-11.0 (Ubuntu 11.0~repack-4)");
+    expect(result.status).toBe("up-to-date");
+    expect(result.installed).toBe("11.0");
+  });
+
+  it("returns unknown for unparseable version", () => {
+    const result = checkWineUpdate("");
+    expect(result.status).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function tarball(version: string) {
+  return {
+    name: `dxvk-${version}.tar.gz`,
+    browser_download_url: `https://example.com/dxvk-${version}.tar.gz`,
+  };
+}
+
+function makeFakeFetch(releases: unknown[]) {
+  return async () => ({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(releases),
+  });
+}
+
+function makeFakeFetchError(status: number) {
+  return async () => ({
+    ok: false,
+    status,
+    json: () => Promise.resolve({}),
+  });
+}


### PR DESCRIPTION
## Summary
- New `update-checker.ts` module with `checkDxvkUpdate()` (async, GitHub API) and `checkWineUpdate()` (local comparison)
- DXVK check reuses existing `dxvk-resolver.ts` infrastructure (filterStableReleases, meetsMinimumVersion)
- Non-intrusive: returns `UpdateStatus` only, never auto-updates
- 9 new tests with injected fetch for full testability

Closes #135

## Test plan
- [x] `pnpm run test:run` — 220 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — compiles
- [x] Stats verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)