### PR TITLE
docs: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@7e4729715543e066e58d1b0e1dc70a4dab16d1f3 # v1.0.13
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac2b3c603fc # v4.0.5

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,4 +32,4 @@ Each EQ instance runs as a native XWayland window. Window management
 uses `wine_helper.exe` (MinGW-compiled Win32 API calls via Wine).
 EQLogParser runs in its own isolated Wine prefix.
 
-For more details, see [AGENTS.md](../AGENTS.md) and the source code.
+For more details, see [AGENTS.md](https://github.com/williamzujkowski/norrath-native/blob/main/AGENTS.md) and the source code.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,15 @@
+title: norrath-native
+description: Deterministic EverQuest deployment toolkit for Ubuntu 24.04 LTS via Wine and DXVK
+remote_theme: pages-themes/minimal@v0.2.0
+plugins:
+  - jekyll-remote-theme
+
+exclude:
+  - api/
+  - "*.png"
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: default


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/pages.yml` for automated GitHub Pages deployment
- Jekyll config with minimal theme in `docs/_config.yml`
- Deploys on push to main when docs change, or via manual trigger
- Fixes broken relative link in docs/README.md

Closes #137

## Test plan
- [x] All tests pass
- [x] Workflow YAML valid
- [x] Enable Pages in repo settings (source: GitHub Actions) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)