### PR TITLE
fix(ci): replace gitleaks with TruffleHog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196e88a9c30 # v2.3.9
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: TruffleHog secret scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
 
   quality:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Replace gitleaks-action (requires paid license) with TruffleHog (free for OSS)
- Uses --only-verified flag to reduce false positives
- Full git history scan preserved

## Test plan
- [x] CI workflow YAML valid
- [x] TruffleHog action runs on public repos without license

🤖 Generated with [Claude Code](https://claude.com/claude-code)