### PR TITLE
fix: dynamic Ubuntu codename + JSDoc cleanup

### DIFF
--- a/scripts/install_prerequisites.sh
+++ b/scripts/install_prerequisites.sh
@@ -136,10 +136,12 @@ install_wine_from_winehq() {
         run sudo wget -qO /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
     fi
 
-    # Add WineHQ repository for Ubuntu 24.04 (Noble)
-    if [[ ! -f /etc/apt/sources.list.d/winehq-noble.sources ]]; then
-        nn_log "  Adding WineHQ Noble repository..."
-        run sudo wget -qNP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources
+    # Add WineHQ repository (detect Ubuntu codename dynamically)
+    local codename
+    codename="$(. /etc/os-release && echo "${UBUNTU_CODENAME:-noble}")"
+    if [[ ! -f "/etc/apt/sources.list.d/winehq-${codename}.sources" ]]; then
+        nn_log "  Adding WineHQ ${codename} repository..."
+        run sudo wget -qNP /etc/apt/sources.list.d/ "https://dl.winehq.org/wine-builds/ubuntu/dists/${codename}/winehq-${codename}.sources"
         run sudo apt-get update -qq
     fi
 

--- a/src/config-injector.ts
+++ b/src/config-injector.ts
@@ -3,6 +3,8 @@
  *
  * Enforces managed settings while preserving user-defined keys.
  * No third-party INI libraries — hand-rolled parser for EQ's format.
+ *
+ * @module config-injector
  */
 
 import * as fs from "node:fs";


### PR DESCRIPTION
## Summary
- Detect Ubuntu codename dynamically via `/etc/os-release` instead of hardcoding "noble"
- Add `@module` JSDoc tag to config-injector.ts

Closes #153

## Test plan
- [x] All 222 tests pass
- [x] ShellCheck clean on modified script

🤖 Generated with [Claude Code](https://claude.com/claude-code)