### PR TITLE
fix: website base URL links

### DIFF
--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -1,5 +1,5 @@
 ---
-const base = import.meta.env.BASE_URL;
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <nav class="sticky top-0 z-50 border-b" style="background-color: var(--color-bg-nav); border-color: var(--color-border);">

--- a/website/src/components/Sidebar.astro
+++ b/website/src/components/Sidebar.astro
@@ -1,5 +1,5 @@
 ---
-const base = import.meta.env.BASE_URL;
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
 const guides = [
   { title: 'Getting Started', href: `${base}guides/getting-started/` },

--- a/website/src/content/guides/troubleshooting.md
+++ b/website/src/content/guides/troubleshooting.md
@@ -70,7 +70,7 @@ make doctor                   # Check DXVK DLL status
 
 ### EQLogParser crashes
 
-See [EQLogParser Setup](eqlogparser-setup.md#troubleshooting).
+See [EQLogParser Setup](/norrath-native/guides/eqlogparser-setup/#troubleshooting).
 
 ## Support Bundle
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-const base = import.meta.env.BASE_URL;
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
 
 <BaseLayout title="Home" description="Deterministic EverQuest deployment toolkit for Ubuntu 24.04 LTS via Wine and DXVK">


### PR DESCRIPTION
## Summary
- Fix missing slash in all navigation links (was `/norrath-nativeguides/`, now `/norrath-native/guides/`)
- Normalize `BASE_URL` with trailing slash in Nav, Sidebar, and index page
- Fix internal markdown link to use absolute path with base prefix

## Test plan
- [x] `npm run build` produces correct href attributes
- [x] Verified all 11 pages have proper `/norrath-native/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)