### PR TITLE
fix: website design audit — headings, footer, hover

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -1,0 +1,15 @@
+---
+const year = new Date().getFullYear();
+---
+
+<footer class="mt-16 border-t py-8" style="border-color: var(--color-border);">
+  <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm" style="color: var(--color-text-muted);">
+      <p>norrath-native &mdash; MIT License &copy; {year} William Zujkowski</p>
+      <div class="flex gap-4">
+        <a href="https://github.com/williamzujkowski/norrath-native" class="hover:text-white transition-colors" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/williamzujkowski/norrath-native/issues" class="hover:text-white transition-colors" target="_blank" rel="noopener">Issues</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import Nav from '../components/Nav.astro';
 import Sidebar from '../components/Sidebar.astro';
+import Footer from '../components/Footer.astro';
 
 interface Props {
   title: string;
@@ -23,9 +24,9 @@ const siteTitle = `${title} | norrath-native`;
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   </head>
-  <body class="min-h-screen">
+  <body class="min-h-screen flex flex-col">
     <Nav />
-    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 flex-1">
       <div class="flex gap-8 py-8">
         <Sidebar />
         <main class="flex-1 min-w-0">
@@ -35,5 +36,6 @@ const siteTitle = `${title} | norrath-native`;
         </main>
       </div>
     </div>
+    <Footer />
   </body>
 </html>

--- a/website/src/pages/guides/[...slug].astro
+++ b/website/src/pages/guides/[...slug].astro
@@ -15,6 +15,5 @@ const { Content } = await render(entry);
 ---
 
 <BaseLayout title={entry.data.title} description={entry.data.description}>
-  <h1>{entry.data.title}</h1>
   <Content />
 </BaseLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -11,19 +11,19 @@ const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
   </p>
 
   <div class="not-prose grid gap-4 sm:grid-cols-2 my-8">
-    <a href={`${base}guides/getting-started/`} class="block rounded-lg p-5 transition-colors hover:brightness-110" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
+    <a href={`${base}guides/getting-started/`} class="card-link block rounded-lg p-5" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
       <h3 class="text-base font-semibold mb-1" style="color: var(--color-text-heading);">Getting Started</h3>
       <p class="text-sm" style="color: var(--color-text-muted);">Install prerequisites, deploy, and launch EQ in minutes.</p>
     </a>
-    <a href={`${base}guides/multiboxing/`} class="block rounded-lg p-5 transition-colors hover:brightness-110" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
+    <a href={`${base}guides/multiboxing/`} class="card-link block rounded-lg p-5" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
       <h3 class="text-base font-semibold mb-1" style="color: var(--color-text-heading);">Multiboxing</h3>
       <p class="text-sm" style="color: var(--color-text-muted);">Run multiple EQ instances with smart window tiling.</p>
     </a>
-    <a href={`${base}guides/chat-setup/`} class="block rounded-lg p-5 transition-colors hover:brightness-110" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
+    <a href={`${base}guides/chat-setup/`} class="card-link block rounded-lg p-5" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
       <h3 class="text-base font-semibold mb-1" style="color: var(--color-text-heading);">Chat Setup</h3>
       <p class="text-sm" style="color: var(--color-text-muted);">4-window raid chat with WCAG-compliant colors.</p>
     </a>
-    <a href={`${base}reference/commands/`} class="block rounded-lg p-5 transition-colors hover:brightness-110" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
+    <a href={`${base}reference/commands/`} class="card-link block rounded-lg p-5" style={`background-color: var(--color-bg-card); border: 1px solid var(--color-border);`}>
       <h3 class="text-base font-semibold mb-1" style="color: var(--color-text-heading);">Command Reference</h3>
       <p class="text-sm" style="color: var(--color-text-muted);">All make targets and CLI commands.</p>
     </a>

--- a/website/src/pages/reference/[...slug].astro
+++ b/website/src/pages/reference/[...slug].astro
@@ -15,6 +15,5 @@ const { Content } = await render(entry);
 ---
 
 <BaseLayout title={entry.data.title} description={entry.data.description}>
-  <h1>{entry.data.title}</h1>
   <Content />
 </BaseLayout>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -115,3 +115,17 @@ html {
 }
 
 .prose strong { color: var(--color-text-heading); }
+
+/* Card hover animation */
+.card-link {
+  transition: border-color 0.2s, transform 0.2s;
+}
+.card-link:hover {
+  border-color: var(--color-accent) !important;
+  transform: translateY(-2px);
+}
+
+/* Smooth scroll target offset for sticky nav */
+:target {
+  scroll-margin-top: 5rem;
+}


### PR DESCRIPTION
## Summary
Visual fixes from Chrome browser audit:
- **Duplicate headings**: removed layout-generated `<h1>` — markdown already has one
- **Footer**: new component with license, GitHub, and Issues links
- **Card hover**: border highlight + subtle lift animation replaces brightness filter
- **Scroll anchor offset**: `:target { scroll-margin-top: 5rem }` for sticky nav

## Test plan
- [x] Astro build produces 11 pages
- [x] All 235 project tests pass
- [x] Visual verification in Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)