### PR TITLE
fix: website overflow and sidebar scroll

### DIFF
--- a/website/src/components/Sidebar.astro
+++ b/website/src/components/Sidebar.astro
@@ -21,7 +21,7 @@ const currentPath = Astro.url.pathname;
 ---
 
 <aside class="hidden lg:block w-56 shrink-0">
-  <div class="sticky top-22 space-y-6">
+  <div class="sticky space-y-6 overflow-y-auto" style="top: 4.5rem; max-height: calc(100vh - 5rem);">
     <div>
       <h3 class="text-xs font-semibold uppercase tracking-wider mb-2" style="color: var(--color-text-muted);">Guides</h3>
       <ul class="space-y-1">

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -26,6 +26,11 @@ html {
   color: var(--color-text);
   font-family: var(--font-sans);
   scroll-behavior: smooth;
+  overflow-x: hidden;
+}
+
+body {
+  overflow-x: hidden;
 }
 
 /* Prose styles for markdown content */


### PR DESCRIPTION
## Summary
- Fix horizontal overflow with overflow-x: hidden on html/body
- Sidebar gets independent scroll with max-height calc and overflow-y: auto
- Fix sticky top value to match nav height

Found during Chrome browser audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)