### PR TITLE
fix: improve contrast ratios for WCAG AA+ compliance

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -10,8 +10,8 @@ const year = new Date().getFullYear();
         norrath-native &mdash; MIT License &copy; {year} William Zujkowski
       </p>
       <div class="flex gap-4">
-        <a href="https://github.com/williamzujkowski/norrath-native" class="transition-colors" style="color: var(--color-text-muted);" onmouseover="this.style.color='var(--color-gold)'" onmouseout="this.style.color='var(--color-text-muted)'" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://github.com/williamzujkowski/norrath-native/issues" class="transition-colors" style="color: var(--color-text-muted);" onmouseover="this.style.color='var(--color-gold)'" onmouseout="this.style.color='var(--color-text-muted)'" target="_blank" rel="noopener">Issues</a>
+        <a href="https://github.com/williamzujkowski/norrath-native" class="footer-link" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/williamzujkowski/norrath-native/issues" class="footer-link" target="_blank" rel="noopener">Issues</a>
       </div>
     </div>
   </div>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -5,14 +5,14 @@ const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 <nav class="sticky top-0 z-50 border-b backdrop-blur-sm" style="background-color: rgba(12, 15, 24, 0.92); border-color: var(--color-border-gold);">
   <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="flex h-14 items-center justify-between">
-      <a href={`${base}`} class="flex items-center gap-2.5 font-semibold transition-colors" style="font-family: var(--font-heading); color: var(--color-gold); font-size: 1.125rem; letter-spacing: 0.02em;">
+      <a href={`${base}`} class="nav-brand flex items-center gap-2.5 font-semibold" style="font-family: var(--font-heading); font-size: 1.125rem; letter-spacing: 0.02em;">
         <span class="text-xl" style="color: var(--color-gold-dim);">&#9876;</span>
         norrath-native
       </a>
-      <div class="flex items-center gap-6 text-sm" style="color: var(--color-text-muted);">
-        <a href={`${base}guides/getting-started/`} class="transition-colors" style="--hover-color: var(--color-gold);" onmouseover="this.style.color='var(--color-gold)'" onmouseout="this.style.color=''">Guides</a>
-        <a href={`${base}reference/commands/`} class="transition-colors" onmouseover="this.style.color='var(--color-gold)'" onmouseout="this.style.color=''">Reference</a>
-        <a href="https://github.com/williamzujkowski/norrath-native" class="transition-colors" target="_blank" rel="noopener" onmouseover="this.style.color='var(--color-gold)'" onmouseout="this.style.color=''">GitHub</a>
+      <div class="flex items-center gap-6 text-sm">
+        <a href={`${base}guides/getting-started/`} class="nav-link">Guides</a>
+        <a href={`${base}reference/commands/`} class="nav-link">Reference</a>
+        <a href="https://github.com/williamzujkowski/norrath-native" class="nav-link" target="_blank" rel="noopener">GitHub</a>
       </div>
     </div>
   </div>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -8,12 +8,12 @@
   --color-bg-nav: #0c0f18;
   --color-border: #1c2236;
   --color-border-gold: #3d3221;
-  --color-text: #c8cdd8;
-  --color-text-muted: #7a8299;
-  --color-text-heading: #e8dcc8;
-  --color-gold: #c9a84c;
-  --color-gold-dim: #8a7234;
-  --color-gold-bright: #e4c565;
+  --color-text: #d0d4de;
+  --color-text-muted: #949bb3;
+  --color-text-heading: #ede2d0;
+  --color-gold: #d4b45c;
+  --color-gold-dim: #9a7f3e;
+  --color-gold-bright: #e8cc6e;
   --color-accent: #5b8def;
   --color-accent-hover: #7aa3f5;
   --color-success: #4ade80;
@@ -193,6 +193,32 @@ body {
   border: none;
   border-top: 1px solid var(--color-border-gold);
   margin: 2rem 0;
+}
+
+/* ─── Navigation ────────────────────────────────────────────────────────── */
+
+.nav-brand {
+  color: var(--color-gold);
+  transition: color 0.15s;
+}
+.nav-brand:hover {
+  color: var(--color-gold-bright);
+}
+
+.nav-link {
+  color: var(--color-text-muted);
+  transition: color 0.15s;
+}
+.nav-link:hover {
+  color: var(--color-gold);
+}
+
+.footer-link {
+  color: var(--color-text-muted);
+  transition: color 0.15s;
+}
+.footer-link:hover {
+  color: var(--color-gold);
 }
 
 /* ─── Cards ─────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary
Measured contrast ratios via Chrome JS audit, boosted all muted text for better readability.

| Element | Before | After |
|---|---|---|
| Sidebar links | 5.1:1 | **7.1:1** |
| Nav links | 5.0:1 | **6.9:1** |
| Card descriptions | 4.6:1 | **6.4:1** |
| H2 headings | 8.6:1 | **9.8:1** |
| Body text | 12.3:1 | **13.3:1** |

Also replaced inline JS hover handlers with CSS classes for better accessibility.

## Test plan
- [x] Contrast ratios measured via JavaScript in Chrome
- [x] All 235 tests pass
- [x] Website builds (11 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)