### PR TITLE
refactor: named constants, remove undocumented alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ make deploy  # Rebuild from scratch
 ```
 norrath-native/
   src/
-    cli.ts               — Unified CLI entry point (22 commands)
+    cli.ts               — Unified CLI entry point (21 commands)
     config.ts            — YAML config, 5 profiles, 47 managed settings
     colors.ts            — 91-color WCAG AA-compliant chat scheme
     layout.ts            — 107-channel → 4-window chat routing

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,6 @@ function printJson(data: unknown): void {
 function commands(): Record<string, () => void> {
   return {
     config: cmdConfig,
-    "config:resolve": cmdConfig,
     "config:settings": cmdConfigSettings,
     "config:settings:ini": cmdConfigSettingsIni,
     "resolution:detect": cmdResolutionDetect,
@@ -170,10 +169,13 @@ function cmdColorsData(): void {
   }
 }
 
+/** EQ default dark background — used for WCAG contrast validation. */
+const EQ_DEFAULT_BG = { r: 13, g: 13, b: 26 } as const;
+
 function cmdColorsValidate(): void {
-  const bgR = parseIntOrDefault(args[1], 13);
-  const bgG = parseIntOrDefault(args[2], 13);
-  const bgB = parseIntOrDefault(args[3], 26);
+  const bgR = parseIntOrDefault(args[1], EQ_DEFAULT_BG.r);
+  const bgG = parseIntOrDefault(args[2], EQ_DEFAULT_BG.g);
+  const bgB = parseIntOrDefault(args[3], EQ_DEFAULT_BG.b);
   const results = validateSchemeContrast({ r: bgR, g: bgG, b: bgB });
   const failing = results.filter((r) => !r.passes);
   if (failing.length > 0) {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -31,7 +31,6 @@ export interface ProjectMetadata {
 /** CLI command names — kept in sync with cli.ts commands() */
 const CLI_COMMANDS: string[] = [
   "config",
-  "config:resolve",
   "config:settings",
   "config:settings:ini",
   "resolution:detect",

--- a/src/resolution.ts
+++ b/src/resolution.ts
@@ -10,9 +10,12 @@
 
 import { type Result, ok, err } from "./types/interfaces.js";
 
+/** Float comparison tolerance for aspect ratio detection. */
+const ASPECT_RATIO_EPSILON = 0.01;
+
 /** Check if a resolution is ultrawide (wider than 16:9) */
 export function isUltrawide(width: number, height: number): boolean {
-  return width / height > 16 / 9 + 0.01; // small epsilon for float comparison
+  return width / height > 16 / 9 + ASPECT_RATIO_EPSILON;
 }
 
 /** Clamp a resolution to 16:9 aspect ratio (EQ's max supported) */


### PR DESCRIPTION
## Summary
- Add `EQ_DEFAULT_BG` constant for WCAG validation (was magic `13,13,26`)
- Add `ASPECT_RATIO_EPSILON` constant (was magic `0.01`)
- Remove undocumented `config:resolve` alias that inflated CLI command count
- 21 CLI commands (was 22)

Found by nexus-agents code quality scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)